### PR TITLE
fix(ci): move npm publish into release-please's own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,23 +45,3 @@ jobs:
           flags: unittests
           fail_ci_if_error: true
           verbose: true
-
-  publish:
-    if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          registry-url: 'https://registry.npmjs.org/'
-      - name: Install dependencies
-        run: npm ci || npm install
-      - name: Build
-        run: npm run build
-      - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,32 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: node
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org/'
+      - name: Install dependencies
+        run: npm ci || npm install
+      - name: Build
+        run: npm run build
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

`v1.5.4` (from #278) got tagged and released on GitHub by release-please, but **never reached npm** — the registry still shows `1.5.3` as latest.

Root cause: `release-please-action` creates the GitHub Release using `GITHUB_TOKEN`, and per [GitHub's documented restriction](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), events triggered by `GITHUB_TOKEN` — `release: published` included — don't fire new workflow runs. `ci.yml`'s `publish` job, gated on exactly that event, silently never ran. No error, no failed check — it just never triggered.

## Fix

Publish directly off `release-please-action`'s own `release_created` output, in the same workflow that creates the release, rather than depending on a webhook event that never fires. This is the pattern release-please's own docs recommend. Moved the publish job from `ci.yml` into `release-please.yml`.

### PR checklist

- [x] All existing and new tests passed after adding code.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.

### Details

Local verification: lint, typecheck, build, full test suite (123/123). The actual publish path can only be verified by the next real release going through — flagging that rather than overclaiming certainty.

**Separate from this PR**: `v1.5.4` itself is still not on npm. Once this merges, the fix only applies going forward — someone needs to decide whether to manually publish `1.5.4` to catch registry up with the GitHub release, or let the next version supersede it.