### PR TITLE
fix(ci): grant id-token: write for npm provenance publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 22.x


### PR DESCRIPTION
## Summary

Following #279, `v1.5.5`'s `publish` job actually ran this time — correctly triggered off release-please's `release_created` output — but failed at the very last step:

```
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

`npm publish --provenance` needs the `id-token: write` permission (for OIDC-based provenance attestation), which the `publish` job never had — the workflow's top-level `permissions:` block only grants `contents`, `issues`, `pull-requests`.

This is a latent bug that almost certainly also existed in the original `ci.yml` publish job before #275/#277/#279 — it just never had the chance to fail on it, since the `release: published` event gating it never fired at all (see #279's description).

## Fix

Add an explicit `permissions` block to the `publish` job granting `contents: read` and `id-token: write`.

### PR checklist

- [x] All existing and new tests passed after adding code.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.

### Details

Local verification: lint, typecheck, build, full test suite (123/123). As with #279, the actual publish path can only be confirmed by the next real release going through.

Per earlier discussion: `v1.5.4` and now `v1.5.5` are both tagged/released on GitHub but missing from npm. Decided to let the next release catch the registry up rather than manually publishing either.