### PR TITLE
fix(ci): upgrade npm for trusted publishing before npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
       - name: Install dependencies
         run: npm ci || npm install
+      - name: Update npm for OIDC trusted publishing support
+        run: npm install -g npm@latest
       - name: Build
         run: npm run build
       - name: Publish to npm


### PR DESCRIPTION
## Summary

Following the npmjs.com Trusted Publisher configuration (Owner/Repo/Workflow filename/environment now registered for `release-please.yml`, with "Allow npm publish" enabled), this adds an explicit npm CLI upgrade before the publish step.

Trusted Publishing's OIDC handshake requires npm CLI >= 11.5.1. Node 22's bundled npm may be older than that, which was flagged as a possible contributing factor to the 404 in #281's follow-up failure alongside the actual root cause (missing Trusted Publisher registration on npmjs.com, now fixed on that end).

### PR checklist

- [x] All existing and new tests passed after adding code.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.

### Details

Local verification: lint, typecheck, build, full test suite (123/123). This is the last piece of the publish pipeline fix — once merged, the next release-please release PR should, for the first time, actually publish successfully to npm.