### PR TITLE
feat: add isPhoneNumber(text) function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const convert = require('textconvert');
 
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case
 - Text analysis: word/letter/sentence/paragraph counting, reading time, etc.
-- Validation: email addresses and URLs
+- Validation: email addresses, URLs, and phone numbers
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
 - Pure, dependency-free, and TypeScript-ready
@@ -94,6 +94,7 @@ const convert = require('textconvert');
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |
 | `isEmail(text)`                              | Validate an email address                             |
 | `isUrl(text)`                                | Validate a URL                                        |
+| `isPhoneNumber(text)`                        | Validate a phone number                               |
 
 See [docs/API.md](docs/API.md) for full parameter, return type, and edge-case details on every function.
 
@@ -102,12 +103,13 @@ See [docs/API.md](docs/API.md) for full parameter, return type, and edge-case de
 ## Quick Examples
 
 ```js
-import { camelCase, count, isEmail, isUrl } from 'textconvert';
+import { camelCase, count, isEmail, isUrl, isPhoneNumber } from 'textconvert';
 
 camelCase('hello world'); // 'helloWorld'
 count('Hello, world!'); // 10
 isEmail('user@example.com'); // true
 isUrl('https://example.com/path?query=123'); // true
+isPhoneNumber('+1-202-555-0173'); // true
 ```
 
 See more usage examples in [docs/RECIPES.md](docs/RECIPES.md).

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,7 @@ This document provides detailed documentation for all public functions exported 
 - [numbersToWords](#numberstowords)
 - [isEmail](#isemail)
 - [isUrl](#isurl)
+- [isPhoneNumber](#isphonenumber)
 
 ---
 
@@ -398,3 +399,35 @@ isUrl('not a url'); // false
 **Edge Cases:**
 
 - Returns `false` for empty input, non-string inputs or wrong protocol/format.
+
+---
+
+## isPhoneNumber
+
+Validates if a string is structurally a valid phone number. This is syntactic validation only — it does not verify that a country calling code is real, that the digit count matches a specific country's numbering plan, or that the number is actually assigned or reachable.
+
+- With a leading `+` (an explicit country code, e.g. E.164): the remaining digits must be between 7 and 15.
+- Without a leading `+` (a bare local number): the digits must be between 10 and 15, since there's no declared country code to trust.
+- Separators (spaces, dashes, dots, parentheses) are allowed and stripped before counting digits.
+
+**Parameters:**
+
+- `text: string` — The string to validate.
+
+**Returns:**
+
+- `boolean` — `true` if valid, `false` otherwise.
+
+**Example:**
+
+```js
+isPhoneNumber('+1-202-555-0173'); // true
+isPhoneNumber('(202) 555 0173'); // true
+isPhoneNumber('5550173'); // false
+```
+
+**Edge Cases:**
+
+- Returns `false` for empty, non-string, or malformed input.
+- Returns `false` for numbers below the international (7-digit) or local (10-digit) floor, or above E.164's 15-digit max.
+- Does not verify the country calling code or the number's real-world validity.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,7 @@ textConvert/
       validation/
         email.ts         # Email validation
         url.ts           # URL validation
+        phoneNumber.ts   # Phone number validation
       conventions.ts    # Case conversion functions
       clear.ts          # Punctuation removal
       count.ts          # Counting utilities (words, sentences, letters)
@@ -35,7 +36,7 @@ textConvert/
 ## Main Modules & Responsibilities
 
 - **text/analysis/**: Text statistics, language detection, and related analysis tools.
-- **text/validation/**: Validation functions (email, URL; future: phone, etc.).
+- **text/validation/**: Validation functions (email, URL, phone number).
 - **text/conventions.ts**: Case conversion (camelCase, PascalCase, etc.).
 - **text/clear.ts**: Remove punctuation and clean text.
 - **text/count.ts**: Count words, sentences, and letters.
@@ -76,7 +77,6 @@ textConvert/
 
 ## Future Directions
 
-- More validators (phone number, etc.)
 - Internationalization and localization
 - More advanced text analytics
 - Documentation website

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -36,13 +36,16 @@ A: Yes, textConvert works in modern browsers and Node.js.
 ## Features & API
 
 **Q: What can textConvert do?**
-A: It can convert text between cases, analyze text (count words, sentences, etc.), validate emails and URLs, detect language, convert numbers to words, and more. See the README and API Reference for details.
+A: It can convert text between cases, analyze text (count words, sentences, etc.), validate emails, URLs, and phone numbers, detect language, convert numbers to words, and more. See the README and API Reference for details.
 
 **Q: How do I validate an email address?**
 A: Use `isEmail('user@example.com')` — returns `true` if valid, `false` otherwise.
 
 **Q: How do I validate a URL?**
 A: Use `isUrl('https://example.com')` — returns `true` if valid, `false` otherwise. Only `http`/`https` URLs are accepted.
+
+**Q: How do I validate a phone number?**
+A: Use `isPhoneNumber('+1-202-555-0173')` — returns `true` if valid, `false` otherwise. This is structural validation only (digit count and format), not a check against real country codes or numbering plans — see [docs/API.md](API.md) for the exact rules.
 
 **Q: How do I add a new function?**
 A: See `docs/ADDING_FUNCTION.md` for a step-by-step guide.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -35,6 +35,16 @@ isUrl('ftp://fileserver'); // false
 isUrl('not a url'); // false
 ```
 
+### Validate a Phone Number
+
+```js
+import { isPhoneNumber } from 'textconvert';
+
+isPhoneNumber('+1-202-555-0173'); // true (international, explicit country code)
+isPhoneNumber('(202) 555 0173'); // true (local, includes area code)
+isPhoneNumber('5550173'); // false (too short, no area code)
+```
+
 ---
 
 ## Case Conversion

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "validation",
     "email-validation",
     "url-validation",
+    "phone-validation",
+    "phone-number",
     "language-detection",
     "typescript"
   ],

--- a/src/text/validation/phoneNumber.ts
+++ b/src/text/validation/phoneNumber.ts
@@ -1,0 +1,49 @@
+/**
+ * Validates if a string is structurally a valid phone number.
+ *
+ * This performs syntactic validation only — it does not verify that a
+ * country calling code is real, that the digit count matches a specific
+ * country's numbering plan, or that the number is actually assigned or
+ * reachable (the same scope `isEmail` and `isUrl` use).
+ *
+ * - With a leading `+` (an explicit country code, e.g. E.164): the
+ *   remaining digits must be between 7 and 15, matching E.164's real
+ *   bounds — some countries have numbers as short as 7 digits total.
+ * - Without a leading `+` (a bare local number): the digits must be
+ *   between 10 and 15, since there's no declared country code to trust —
+ *   this requires something long enough to plausibly include an area or
+ *   city code rather than a bare subscriber number.
+ * - Separators (spaces, dashes, dots, parentheses) are allowed and
+ *   stripped before counting digits.
+ *
+ * @param text - The string to validate as a phone number
+ * @returns boolean indicating if the string is a structurally valid phone number
+ *
+ * @example
+ * ```typescript
+ * isPhoneNumber('+1-202-555-0173')  // true
+ * isPhoneNumber('(202) 555 0173')   // true
+ * isPhoneNumber('5550173')          // false (too short, no area code)
+ * ```
+ */
+export function isPhoneNumber(text: string): boolean {
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
+
+  const trimmed = text.trim();
+
+  // Only digits, spaces, dashes, dots, and parentheses are allowed, with an
+  // optional single leading '+' to signal an explicit country code.
+  if (!/^\+?[\d\s().-]+$/.test(trimmed)) {
+    return false;
+  }
+
+  const digits = trimmed.replace(/\D/g, '');
+
+  if (trimmed.startsWith('+')) {
+    return digits.length >= 7 && digits.length <= 15;
+  }
+
+  return digits.length >= 10 && digits.length <= 15;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -7,6 +7,7 @@ import { count, countSentences, countWords } from './text/count';
 import { reverse } from './text/reverse';
 import { spread } from './text/spread';
 import { isEmail } from './text/validation/email';
+import { isPhoneNumber } from './text/validation/phoneNumber';
 import { isUrl } from './text/validation/url';
 import { numbersToWords } from './numbers/numbersToWords';
 
@@ -19,6 +20,7 @@ export {
   detectLanguage,
   getTextStats,
   isEmail,
+  isPhoneNumber,
   isUrl,
   kebabCase,
   Language,

--- a/tests/Text/Validation/phoneNumber.test.ts
+++ b/tests/Text/Validation/phoneNumber.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { isPhoneNumber } from '../../../src/text/validation/phoneNumber';
+
+describe('#isPhoneNumber', () => {
+  // Valid international numbers (leading '+', 7-15 digits)
+  it('should return true for valid international (E.164-style) numbers', () => {
+    const validInternational = [
+      '+1-202-555-0173',
+      '+1 202 555 0173',
+      '+12025550173',
+      '+44 20 7946 0958',
+      '+33 1 42 68 53 00',
+      '+683 4001', // Niue - one of the shortest real E.164 numbers
+      '+61 2 9374 4000',
+    ];
+
+    validInternational.forEach((phone) => {
+      expect(isPhoneNumber(phone)).toBe(true);
+    });
+  });
+
+  // Valid local numbers (no '+', 10-15 digits)
+  it('should return true for valid local numbers with an area code', () => {
+    const validLocal = [
+      '(202) 555 0173',
+      '(202) 555-0173',
+      '202-555-0173',
+      '202.555.0173',
+      '2025550173',
+      '020 7946 0958', // UK-style with leading trunk digit
+    ];
+
+    validLocal.forEach((phone) => {
+      expect(isPhoneNumber(phone)).toBe(true);
+    });
+  });
+
+  // Invalid numbers
+  it('should return false for invalid or too-short numbers', () => {
+    const invalidNumbers = [
+      '',
+      'not a phone number',
+      '5550173', // Too short, no area code
+      '123456789', // 9 digits, still too short without a country code
+      '+123456', // 6 digits, below the 7-digit international floor
+      '+1234567890123456', // 16 digits, above E.164's max
+      '12345678901234567', // Way too long
+      '+1-202-555-01AB', // Letters
+      '202 555 CALL', // Vanity letters not supported
+      '++1 202 555 0173', // Double plus
+      '1+202+555+0173', // Plus not at the start
+    ];
+
+    invalidNumbers.forEach((phone) => {
+      expect(isPhoneNumber(phone)).toBe(false);
+    });
+  });
+
+  // Edge cases for various input types
+  it('should handle non-string inputs correctly', () => {
+    // @ts-expect-error Testing null input
+    expect(isPhoneNumber(null)).toBe(false);
+    // @ts-expect-error Testing undefined input
+    expect(isPhoneNumber(undefined)).toBe(false);
+    // @ts-expect-error Testing number input
+    expect(isPhoneNumber(2025550173)).toBe(false);
+    // @ts-expect-error Testing object input
+    expect(isPhoneNumber({})).toBe(false);
+    // @ts-expect-error Testing array input
+    expect(isPhoneNumber([])).toBe(false);
+    // @ts-expect-error Testing boolean input
+    expect(isPhoneNumber(true)).toBe(false);
+    // @ts-expect-error Testing boolean input
+    expect(isPhoneNumber(false)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#243`

Adds `isPhoneNumber(text: string): boolean`. Spec was researched and discussed on the issue first (see [this comment](https://github.com/Monsieur-Nico/textConvert/issues/243#issuecomment-5531309217)) rather than reaching for a per-locale regex table, which is exactly what causes most of validator.js's `isMobilePhone` bug reports (wrong-length numbers accepted/rejected per country).

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _N/A_

### Details

Matches `isEmail`/`isUrl`'s existing scope: structural/syntactic validation only, not existence or reachability. Digit-count floor depends on whether a country code is declared:

- **With a leading `+`** (explicit country code, E.164-style): 7-15 digits — 15 is E.164's real max, 7 is a real practical floor (some countries have valid numbers that short, e.g. Niue).
- **Without one** (bare local number): 10-15 digits — stricter on purpose, since there's no declared country code to trust; requires something long enough to plausibly include an area/city code rather than a bare subscriber number.

Separators (spaces, dashes, dots, parentheses) are stripped before counting digits, so formatting style doesn't matter.

**Explicit limitations** (documented in `docs/API.md`, same pattern as `isEmail`/`isUrl`): does not verify a country calling code is real, does not verify the digit count matches a specific country's actual numbering plan, no reachability check.

Also updated: `docs/API.md` (new entry + TOC), `docs/ARCHITECTURE.md` (removed the now-stale "future: phone" references), `docs/FAQ.md`, `docs/RECIPES.md`, README (Features, API Reference table, Quick Examples), `package.json` keywords, and the GitHub repo topics (added `phone-validation`).

### References

Closes #243. Spec discussion: https://github.com/Monsieur-Nico/textConvert/issues/243#issuecomment-5531309217