### PR TITLE
fix(ci): force IPv4-first DNS resolution to stop Node 24 npm ci hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
 
+    env:
+      # Works around Node's IPv6-first DNS resolution ("Happy Eyeballs")
+      # hanging for minutes on GitHub-hosted runners when IPv6 is
+      # advertised but not actually reachable - observed specifically
+      # on the 24.x leg of this matrix, npm ci hanging indefinitely.
+      NODE_OPTIONS: '--dns-result-order=ipv4first'
+
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

_(Not related to an issue.)_

This commit was originally pushed to #299's branch but landed after that PR had already merged, so it never made it into `main` — recreating it here on top of current `main`.

The 24.x leg of the test matrix hung on `npm ci` for 5+ minutes (reproduced twice) while 22.x, running the exact same lockfile at the same commit, installed in seconds — ruling out the dependency set or npm's registry as the cause, since both matrix entries hit the same lockfile/registry independently. One of the hung runs did eventually complete (5m31s vs 22.x's 31s) rather than failing outright, which matches Node's IPv6-first "Happy Eyeballs" DNS resolution hanging when a GitHub-hosted runner advertises IPv6 via DNS but can't actually route over it — a slow-fallback pattern, not a hard failure — and a behavior that differs across Node versions.

### PR checklist

- [x] All existing and new tests passed after adding code.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _N/A_

### Details

`NODE_OPTIONS=--dns-result-order=ipv4first` forces IPv4 first, which is the standard workaround for this class of issue. Applied at the `test` job level in `ci.yml` so it covers every step, not just install.

### References

N/A