### PR TITLE
revert: force IPv4-first DNS resolution workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,6 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
 
-    env:
-      # Works around Node's IPv6-first DNS resolution ("Happy Eyeballs")
-      # hanging for minutes on GitHub-hosted runners when IPv6 is
-      # advertised but not actually reachable - observed specifically
-      # on the 24.x leg of this matrix, npm ci hanging indefinitely.
-      NODE_OPTIONS: '--dns-result-order=ipv4first'
-
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

_(Not related to an issue.)_

Reverts the `NODE_OPTIONS=--dns-result-order=ipv4first` workaround added in #301. Follow-up evidence didn't hold up the original diagnosis.

### PR checklist

- [x] All existing and new tests passed after adding code.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [x] Other (please describe):
  > Revert of a prior CI workaround.

### Details

After #301 merged, 22.x (which had never been affected by the original hangs) took 7+ minutes on install on a later run while 24.x was fast — breaking the clean Node-24-specific correlation the original fix was based on. A subsequent run then hit a genuine Cloudflare 502 from `registry.npmjs.org`'s audit endpoint (confirmed directly in the job log), unrelated to DNS family selection entirely.

This all points to intermittent npm registry / GitHub runner network flakiness unrelated to Node version, which the workaround doesn't actually address. Removing it rather than keeping an unproven fix in place.

### References

N/A