### PR TITLE
feat: add slugify function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const convert = require('textconvert');
 
 ## ✨ Features
 
-- Case conversion: camelCase, PascalCase, snake_case, kebab-case
+- Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify
 - Text analysis: word/letter/sentence/paragraph counting, reading time, etc.
 - Validation: email addresses, URLs, and phone numbers
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
@@ -90,6 +90,7 @@ const convert = require('textconvert');
 | `pascalCase(text)`                           | Convert to PascalCase                                 |
 | `snakeCase(text)`                            | Convert to snake_case                                 |
 | `kebabCase(text)`                            | Convert to kebab-case                                 |
+| `slugify(text)`                              | Convert to a URL-safe slug                            |
 | `clear(text)`                                | Remove punctuation from text                          |
 | `count(text, countNumbers?)`                 | Count letters (optionally including numbers)          |
 | `countWords(text)`                           | Count words                                           |

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,6 +16,7 @@ This document provides detailed documentation for all public functions exported 
 - [pascalCase](#pascalcase)
 - [snakeCase](#snakecase)
 - [kebabCase](#kebabcase)
+- [slugify](#slugify)
 - [getTextStats](#gettextstats)
 - [detectLanguage](#detectlanguage)
 - [numbersToWords](#numberstowords)
@@ -267,6 +268,32 @@ kebabCase('hello world'); // 'hello-world'
 **Edge Cases:**
 
 - Returns an error message for empty input.
+
+---
+
+## slugify
+
+Converts a string into a URL-safe slug: lowercase, punctuation stripped, separators collapsed to a single `-`, and accented characters normalized to their plain-ASCII equivalents.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The slugified string.
+
+**Example:**
+
+```js
+slugify('Hello, World! 100% Awesome'); // 'hello-world-100-awesome'
+slugify('Café Résumé Review'); // 'cafe-resume-review'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Numbers are preserved (not treated as separators).
 
 ---
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -60,6 +60,18 @@ snakeCase('hello world'); // 'hello_world'
 kebabCase('hello world'); // 'hello-world'
 ```
 
+### Generate a URL Slug for a Blog Post Title
+
+```js
+import { slugify } from 'textconvert';
+
+function buildPostUrl(title) {
+  return `/blog/${slugify(title)}`;
+}
+
+buildPostUrl('10 Tips for Better Résumés!'); // '/blog/10-tips-for-better-resumes'
+```
+
 ---
 
 ## Text Analysis

--- a/src/assets/regex.ts
+++ b/src/assets/regex.ts
@@ -13,6 +13,7 @@ const regex = {
     nonAlphabetic: /[^A-Za-z]/g,
     nonAlphaTest: /[^A-Za-z]/,
     punctuation: /[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]/g,
+    nonAlphaNumeric: /[^A-Za-z0-9]+/g,
   },
 };
 

--- a/src/text/slugify.ts
+++ b/src/text/slugify.ts
@@ -1,0 +1,36 @@
+import { regex } from '../assets/regex';
+
+const { values } = regex;
+
+// Matches Unicode combining diacritical marks (code points 0x0300-0x036F),
+// the marks left behind after NFD-decomposing an accented character (e.g.
+// an accented "e" decomposes into a plain "e" plus a combining mark).
+const combiningMarks = new RegExp(
+  `[${String.fromCharCode(0x0300)}-${String.fromCharCode(0x036f)}]`,
+  'g',
+);
+
+/**
+ * Convert text into a URL-safe slug: lowercase, punctuation stripped,
+ * separators collapsed to a single "-", and accented characters normalized
+ * to their plain-ASCII equivalents.
+ *
+ * @param text Text to slugify.
+ * @returns A lowercase, hyphen-separated, URL-safe slug.
+ * @example
+ * slugify('Hello, World! 100% Awesome'); // 'hello-world-100-awesome'
+ * slugify('  Multiple   Spaces  '); // 'multiple-spaces'
+ */
+export function slugify(text: string): string {
+  // Make sure there's an input
+  if (!text) return 'Please provide a valid input text';
+
+  // Decompose accented characters (NFD) and strip the combining marks,
+  // leaving plain-ASCII equivalents.
+  const normalized = text.normalize('NFD').replace(combiningMarks, '');
+
+  // Split on runs of non-alphanumeric characters and join with "-"
+  const words = normalized.toLowerCase().split(values.nonAlphaNumeric);
+
+  return words.filter((word) => word.length > 0).join('-');
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -10,6 +10,7 @@ import { isEmail } from './text/validation/email';
 import { isPhoneNumber } from './text/validation/phoneNumber';
 import { isUrl } from './text/validation/url';
 import { numbersToWords } from './numbers/numbersToWords';
+import { slugify } from './text/slugify';
 
 export {
   camelCase,
@@ -28,6 +29,7 @@ export {
   numbersToWords,
   pascalCase,
   reverse,
+  slugify,
   snakeCase,
   spread,
   TextStatistics,

--- a/tests/Text/slugify.test.ts
+++ b/tests/Text/slugify.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { slugify } from '../../src/textConvert';
+
+describe('#slugify', () => {
+  it("should return 'hello-world-100-awesome' for 'Hello, World! 100% Awesome'", () => {
+    expect(slugify('Hello, World! 100% Awesome')).toBe('hello-world-100-awesome');
+  });
+
+  it("should return 'cafe-resume-review' for 'Café Résumé Review'", () => {
+    expect(slugify('Café Résumé Review')).toBe('cafe-resume-review');
+  });
+
+  it("should return 'multiple-spaces' for '  Multiple   Spaces  '", () => {
+    expect(slugify('  Multiple   Spaces  ')).toBe('multiple-spaces');
+  });
+
+  it('should collapse runs of punctuation into a single separator', () => {
+    expect(slugify('foo---bar___baz')).toBe('foo-bar-baz');
+  });
+
+  it('should preserve numbers', () => {
+    expect(slugify('Top 10 Tips')).toBe('top-10-tips');
+  });
+
+  it("should return 'Please provide a valid input text' for empty input", () => {
+    expect(slugify('')).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#288`

Adds `slugify(text: string): string`, converting text into a URL-safe slug: lowercase, punctuation stripped, separators collapsed to a single `-`, and accented characters normalized to their plain-ASCII equivalents.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

_Accent normalization uses `String.prototype.normalize('NFD')` to decompose accented characters (e.g. é → e + combining mark), then strips the combining marks (Unicode range 0x0300–0x036F, built from `String.fromCharCode` rather than a regex escape literal, for source clarity). Word-splitting reuses the same regex-asset pattern as `clear.ts`/`conventions.ts` by adding a new `nonAlphaNumeric` entry to `src/assets/regex.ts`, rather than duplicating punctuation-splitting logic inline — the existing `nonAlphabetic` pattern couldn't be reused directly since it strips digits, which slugify needs to preserve (e.g. `'Top 10 Tips'` → `'top-10-tips'`)._

_Added 6 new tests covering the issue's examples plus punctuation-run collapsing and number preservation. Updated README.md, docs/API.md, and docs/RECIPES.md per [docs/ADDING_FUNCTION.md](docs/ADDING_FUNCTION.md). Full suite (133 tests), lint, typecheck, and build all pass._

### References

Closes #288.
