### PR TITLE
feat: add truncate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ const convert = require('textconvert');
 
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case
 - Text analysis: word/letter/sentence/paragraph counting, reading time, etc.
+- Text utilities: truncate with word-boundary awareness
 - Validation: email addresses, URLs, and phone numbers
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
@@ -96,6 +97,7 @@ const convert = require('textconvert');
 | `countSentences(text)`                       | Count sentences                                       |
 | `reverse(text)`                              | Reverse a string                                      |
 | `spread(text, clear?)`                       | Split a string into an array of characters            |
+| `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis        |
 | `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time) |
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,7 @@ This document provides detailed documentation for all public functions exported 
 - [countSentences](#countsentences)
 - [reverse](#reverse)
 - [spread](#spread)
+- [truncate](#truncate)
 - [camelCase](#camelcase)
 - [pascalCase](#pascalcase)
 - [snakeCase](#snakecase)
@@ -171,6 +172,36 @@ spread('Hello, world!', true); // ['H', 'e', ...]
 **Edge Cases:**
 
 - Returns an error message for invalid input type or empty string.
+
+---
+
+## truncate
+
+Shortens text to a maximum length, appending an ellipsis when truncation happens. `maxLength` includes the ellipsis itself.
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `maxLength: number` — Maximum length of the returned string, including the ellipsis.
+- `options?: { ellipsis?: string; byWords?: boolean }` — `ellipsis` overrides the default `'...'`; `byWords` (default `false`) snaps the cut to the last full word instead of cutting mid-word.
+
+**Returns:**
+
+- `string` — The truncated string, or the original string unchanged if it's already within `maxLength`.
+
+**Example:**
+
+```js
+truncate('The quick brown fox jumps over the lazy dog', 20); // 'The quick brown f...'
+truncate('The quick brown fox jumps over the lazy dog', 20, { byWords: true }); // 'The quick brown...'
+truncate('Short text', 20); // 'Short text'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- If `maxLength` is smaller than or equal to the ellipsis length, returns as much of the ellipsis as fits.
+- With `byWords`, falls back to a hard cut if there's no word boundary before the cut point.
 
 ---
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -9,6 +9,7 @@ This guide provides practical examples and advanced usage patterns for the textC
 - [Basic Validation](#basic-validation)
 - [Case Conversion](#case-conversion)
 - [Text Analysis](#text-analysis)
+- [Text Utilities](#text-utilities)
 - [Combining Functions](#combining-functions)
 - [Custom Utilities](#custom-utilities)
 
@@ -76,6 +77,20 @@ const stats = getTextStats('Hello world! This is a test.');
 //   sentenceCount: 2,
 //   ...
 // }
+```
+
+---
+
+## Text Utilities
+
+### Truncate a Preview for a Card or List Item
+
+```js
+import { truncate } from 'textconvert';
+
+const summary = 'The quick brown fox jumps over the lazy dog';
+truncate(summary, 20); // 'The quick brown f...'
+truncate(summary, 20, { byWords: true }); // 'The quick brown...'
 ```
 
 ---

--- a/src/text/truncate.ts
+++ b/src/text/truncate.ts
@@ -1,0 +1,40 @@
+/**
+ * Shortens text to a maximum length, appending an ellipsis when truncation
+ * happens. `maxLength` includes the ellipsis itself.
+ *
+ * @param text Text to truncate.
+ * @param maxLength Maximum length of the returned string, including the ellipsis.
+ * @param options.ellipsis String appended when the text is truncated. Default is '...'.
+ * @param options.byWords When true, truncates at the last full word instead of cutting mid-word. Default is false.
+ * @returns The truncated string, or the original string unchanged if it's already within maxLength.
+ * @example
+ * truncate('The quick brown fox jumps over the lazy dog', 20); // 'The quick brown f...'
+ * truncate('The quick brown fox jumps over the lazy dog', 20, { byWords: true }); // 'The quick brown...'
+ * truncate('Short text', 20); // 'Short text'
+ */
+export function truncate(
+  text: string,
+  maxLength: number,
+  options: { ellipsis?: string; byWords?: boolean } = {},
+): string {
+  // Make sure there's an input
+  if (!text) return 'Please provide a valid input text';
+
+  // No truncation needed
+  if (text.length <= maxLength) return text;
+
+  const { ellipsis = '...', byWords = false } = options;
+
+  // Not enough room for any text alongside the ellipsis — return as much of
+  // the ellipsis as fits.
+  if (maxLength <= ellipsis.length) return ellipsis.slice(0, Math.max(maxLength, 0));
+
+  let cut = text.slice(0, maxLength - ellipsis.length);
+
+  if (byWords) {
+    const lastSpace = cut.lastIndexOf(' ');
+    if (lastSpace > 0) cut = cut.slice(0, lastSpace);
+  }
+
+  return cut + ellipsis;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -10,6 +10,7 @@ import { isEmail } from './text/validation/email';
 import { isPhoneNumber } from './text/validation/phoneNumber';
 import { isUrl } from './text/validation/url';
 import { numbersToWords } from './numbers/numbersToWords';
+import { truncate } from './text/truncate';
 
 export {
   camelCase,
@@ -31,4 +32,5 @@ export {
   snakeCase,
   spread,
   TextStatistics,
+  truncate,
 };

--- a/tests/Text/truncate.test.ts
+++ b/tests/Text/truncate.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { truncate } from '../../src/textConvert';
+
+describe('#truncate', () => {
+  it("should return 'The quick brown f...' for maxLength 20", () => {
+    expect(truncate('The quick brown fox jumps over the lazy dog', 20)).toBe(
+      'The quick brown f...',
+    );
+  });
+
+  it("should return 'The quick brown...' for maxLength 20 with byWords", () => {
+    expect(truncate('The quick brown fox jumps over the lazy dog', 20, { byWords: true })).toBe(
+      'The quick brown...',
+    );
+  });
+
+  it('should return the text unchanged when already within maxLength', () => {
+    expect(truncate('Short text', 20)).toBe('Short text');
+  });
+
+  it('should support a custom ellipsis', () => {
+    expect(truncate('The quick brown fox', 10, { ellipsis: '~' })).toBe('The quick~');
+  });
+
+  it('should return the ellipsis (sliced) when maxLength is smaller than the ellipsis', () => {
+    expect(truncate('Hello world', 2)).toBe('..');
+    expect(truncate('Hello world', 0)).toBe('');
+  });
+
+  it('should hard-cut when byWords finds no earlier word boundary', () => {
+    expect(truncate('Supercalifragilisticexpialidocious', 10, { byWords: true })).toBe(
+      'Superca...',
+    );
+  });
+
+  it("should return 'Please provide a valid input text' for empty input", () => {
+    expect(truncate('', 10)).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#291`

Adds `truncate(text: string, maxLength: number, options?: { ellipsis?: string; byWords?: boolean }): string`, shortening text to a maximum length and appending an ellipsis when truncation happens.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

_Settles the two design questions raised in the issue:_

- _`maxLength` includes the ellipsis in the count (not added on top) — verified against the issue's own example: `truncate(text, 20)` produces a 20-character result including the trailing `'...'`._
- _If `maxLength` is smaller than or equal to the ellipsis length, returns as much of the ellipsis as fits (e.g. `truncate('Hello world', 2)` → `'..'`), rather than throwing or returning an empty/malformed string._

_`byWords` snaps the cut point back to the last space before the truncation boundary; if no space exists before that point (e.g. one long word), it falls back to a hard cut rather than returning an overlong or empty string. Added 7 tests covering the issue's examples, custom ellipsis, the too-short-maxLength edge case, and the no-word-boundary fallback._

_Updated README.md, docs/API.md, and docs/RECIPES.md per [docs/ADDING_FUNCTION.md](docs/ADDING_FUNCTION.md). Full suite (134 tests), lint, typecheck, and build all pass. Branched off the same `main` as #307 (slugify) — no file overlap between the two._

### References

Closes #291.
