### PR TITLE
feat: add maskText function

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const convert = require('textconvert');
 
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify
 - Text analysis: word/letter/sentence/paragraph counting, reading time, etc.
-- Text utilities: truncate with word-boundary awareness
+- Text utilities: truncate with word-boundary awareness, partial masking for display
 - Validation: email addresses, URLs, and phone numbers
 - Extraction: pull email addresses and URLs out of a block of text
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
@@ -100,6 +100,7 @@ const convert = require('textconvert');
 | `reverse(text)`                              | Reverse a string                                      |
 | `spread(text, clear?)`                       | Split a string into an array of characters            |
 | `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis        |
+| `maskText(text, options?)`                   | Partially mask a string for display                   |
 | `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time) |
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,7 @@ This document provides detailed documentation for all public functions exported 
 - [reverse](#reverse)
 - [spread](#spread)
 - [truncate](#truncate)
+- [maskText](#masktext)
 - [camelCase](#camelcase)
 - [pascalCase](#pascalcase)
 - [snakeCase](#snakecase)
@@ -544,3 +545,36 @@ extractUrls('Check out https://example.com and http://another.example.org/path f
 - Returns an empty array for empty input or when no valid URL is found.
 - Only `http://`/`https://` are recognized as URL starts (matching `isUrl`'s scope).
 - Excludes common wrapping delimiters (quotes, angle brackets, parentheses) from the match, and strips trailing sentence punctuation before validating.
+
+---
+
+## maskText
+
+Partially masks a string for display purposes (e.g. showing a masked email or card number in a UI without exposing the full value).
+
+If neither `visibleStart` nor `visibleEnd` is given, the first 2 characters are shown by default. Specifying either one turns off that implicit default for the side you didn't specify — e.g. passing only `visibleEnd` hides the start entirely, rather than also showing the first 2 characters.
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `options.visibleStart?: number` — Number of characters to leave visible at the start.
+- `options.visibleEnd?: number` — Number of characters to leave visible at the end.
+- `options.maskChar?: string` — Character(s) to use for masked positions. Default is `'*'`.
+
+**Returns:**
+
+- `string` — The masked string, or the original string unchanged if the requested visible portions cover the whole string.
+
+**Example:**
+
+```js
+maskText('jordan@example.com'); // 'jo****************'
+maskText('4111111111111234', { visibleEnd: 4 }); // '************1234'
+maskText('secret-token-value', { visibleStart: 0, visibleEnd: 0, maskChar: '#' }); // '##################'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- If the requested visible portions (start + end) cover the whole string, returns the string unchanged rather than over-masking.
+- `visibleStart`/`visibleEnd` are clamped to the string's length, and clamped further so the two visible portions never overlap.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -123,6 +123,19 @@ truncate(summary, 20); // 'The quick brown f...'
 truncate(summary, 20, { byWords: true }); // 'The quick brown...'
 ```
 
+### Mask Sensitive Data for Display
+
+```js
+import { maskText, isEmail } from 'textconvert';
+
+function maskEmail(email) {
+  return isEmail(email) ? maskText(email) : email;
+}
+
+maskEmail('jordan@example.com'); // 'jo****************'
+maskText('4111111111111234', { visibleEnd: 4 }); // '************1234' (card number, last 4 visible)
+```
+
 ---
 
 ## Combining Functions

--- a/src/text/mask.ts
+++ b/src/text/mask.ts
@@ -1,0 +1,46 @@
+/**
+ * Partially masks a string for display purposes (e.g. showing a masked
+ * email or card number in a UI without exposing the full value).
+ *
+ * If neither `visibleStart` nor `visibleEnd` is given, the first 2
+ * characters are shown by default. Specifying either one turns off that
+ * implicit default for the side you didn't specify — e.g. passing only
+ * `visibleEnd` hides the start entirely, rather than also showing the
+ * first 2 characters.
+ *
+ * @param text Text to mask.
+ * @param options.visibleStart Number of characters to leave visible at the start.
+ * @param options.visibleEnd Number of characters to leave visible at the end.
+ * @param options.maskChar Character(s) to use for masked positions. Default is '*'.
+ * @returns The masked string, or the original string unchanged if the
+ * requested visible portions cover the whole string.
+ * @example
+ * maskText('jordan@example.com'); // 'jo****************'
+ * maskText('4111111111111234', { visibleEnd: 4 }); // '************1234'
+ * maskText('secret-token-value', { visibleStart: 0, visibleEnd: 0, maskChar: '#' }); // '##################'
+ */
+export function maskText(
+  text: string,
+  options: { visibleStart?: number; visibleEnd?: number; maskChar?: string } = {},
+): string {
+  if (!text) return 'Please provide a valid input text';
+
+  const { visibleStart, visibleEnd, maskChar = '*' } = options;
+  const visibilitySpecified = visibleStart !== undefined || visibleEnd !== undefined;
+
+  const start = Math.max(0, visibleStart ?? (visibilitySpecified ? 0 : 2));
+  const end = Math.max(0, visibleEnd ?? 0);
+
+  // Clamp to the string's length so the visible portions never overlap.
+  const clampedStart = Math.min(start, text.length);
+  const clampedEnd = Math.min(end, text.length - clampedStart);
+
+  const maskedLength = text.length - clampedStart - clampedEnd;
+  if (maskedLength <= 0) return text;
+
+  return (
+    text.slice(0, clampedStart) +
+    maskChar.repeat(maskedLength) +
+    text.slice(text.length - clampedEnd)
+  );
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -5,6 +5,7 @@ import { getTextStats, TextStatistics } from './text/analysis/statistics';
 import { clear } from './text/clear';
 import { count, countSentences, countWords } from './text/count';
 import { extractEmails, extractUrls } from './text/extract';
+import { maskText } from './text/mask';
 import { reverse } from './text/reverse';
 import { spread } from './text/spread';
 import { isEmail } from './text/validation/email';
@@ -30,6 +31,7 @@ export {
   kebabCase,
   Language,
   LanguageDetectionResult,
+  maskText,
   numbersToWords,
   pascalCase,
   reverse,

--- a/tests/Text/mask.test.ts
+++ b/tests/Text/mask.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { maskText } from '../../src/textConvert';
+
+describe('#maskText', () => {
+  it('should show the first 2 characters by default', () => {
+    expect(maskText('jordan@example.com')).toBe('jo****************');
+  });
+
+  it('should hide the start entirely when only visibleEnd is specified', () => {
+    expect(maskText('4111111111111234', { visibleEnd: 4 })).toBe('************1234');
+  });
+
+  it('should support a custom mask character with both ends hidden', () => {
+    expect(maskText('secret-token-value', { visibleStart: 0, visibleEnd: 0, maskChar: '#' })).toBe(
+      '##################',
+    );
+  });
+
+  it('should hide the end entirely when only visibleStart is specified', () => {
+    expect(maskText('abcdefgh', { visibleStart: 3 })).toBe('abc*****');
+  });
+
+  it('should return the text unchanged when the visible portions cover the whole string', () => {
+    expect(maskText('ab', { visibleStart: 10 })).toBe('ab');
+    expect(maskText('abcdef', { visibleStart: 3, visibleEnd: 5 })).toBe('abcdef');
+  });
+
+  it('should fully mask when both visibleStart and visibleEnd are 0', () => {
+    expect(maskText('ab', { visibleStart: 0, visibleEnd: 0 })).toBe('**');
+  });
+
+  it("should return 'Please provide a valid input text' for empty input", () => {
+    expect(maskText('')).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#296`

Adds `maskText(text: string, options?: { visibleStart?: number; visibleEnd?: number; maskChar?: string }): string`, which partially masks a string for display purposes (e.g. showing a masked email or card number in a UI without exposing the full value).

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

_The issue explicitly asked for the defaults and the exceeds-length behavior to be decided and documented, so here's the reasoning:_

- _`visibleStart` defaults to 2 **only** when neither `visibleStart` nor `visibleEnd` is specified. Specifying either one turns off that implicit default for the side you didn't specify — e.g. `{ visibleEnd: 4 }` hides the start entirely rather than also showing the first 2 characters. This matches the natural "mask a card number, show only the last 4" use case without needing to also pass `visibleStart: 0` every time._
- _`visibleStart`/`visibleEnd` are clamped to the string's length, and further clamped so the two visible portions can't overlap; if they cover the whole string, the original string is returned unchanged rather than doing nothing/erroring._
- _`maskChar` defaults to `'*'` and can be any string (not just a single character) — each masked position is replaced by one copy of it._

_Tested against all three of the issue's examples (verified exact output, not eyeballed) plus edge cases: visible portions exceeding the string length, overlapping start/end requests, and empty input. Full suite (159 tests), lint, typecheck, and build all pass._

_This clears the last blocker on `redact` (#311) — `extractEmails`/`extractUrls` (#294) landed earlier, so `redact` is now fully unblocked._

### References

Closes #296.
