### PR TITLE
feat: add redact function

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const convert = require('textconvert');
 
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify
 - Text analysis: word/letter/sentence/paragraph counting, reading time, etc.
-- Text utilities: truncate with word-boundary awareness, partial masking for display
+- Text utilities: truncate with word-boundary awareness, partial masking for display, PII redaction
 - Validation: email addresses, URLs, and phone numbers
 - Extraction: pull email addresses and URLs out of a block of text
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
@@ -101,6 +101,7 @@ const convert = require('textconvert');
 | `spread(text, clear?)`                       | Split a string into an array of characters            |
 | `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis        |
 | `maskText(text, options?)`                   | Partially mask a string for display                   |
+| `redact(text, options?)`                     | Mask emails and phone numbers embedded in text        |
 | `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time) |
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,7 @@ This document provides detailed documentation for all public functions exported 
 - [spread](#spread)
 - [truncate](#truncate)
 - [maskText](#masktext)
+- [redact](#redact)
 - [camelCase](#camelcase)
 - [pascalCase](#pascalcase)
 - [snakeCase](#snakecase)
@@ -578,3 +579,35 @@ maskText('secret-token-value', { visibleStart: 0, visibleEnd: 0, maskChar: '#' }
 - Returns an error message for empty input.
 - If the requested visible portions (start + end) cover the whole string, returns the string unchanged rather than over-masking.
 - `visibleStart`/`visibleEnd` are clamped to the string's length, and clamped further so the two visible portions never overlap.
+
+---
+
+## redact
+
+Scans free-form text for embedded PII (emails and phone numbers) and masks each match in place, using `extractEmails` to locate emails and `maskText` to mask every match — for sanitizing logs, support tickets, or user-generated content before storage or display.
+
+**Parameters:**
+
+- `text: string` — The text to redact.
+- `options.types?: Array<'email' | 'phone'>` — Which PII types to redact. Default is both.
+- `options.maskChar?: string` — Character(s) to use for masked positions, passed through to `maskText`. Default is `'*'`.
+
+**Returns:**
+
+- `string` — The text with each detected match masked in place.
+
+**Example:**
+
+```js
+redact('Contact me at jordan@example.com or 555-123-4567');
+// 'Contact me at jo**************** or 55**********'
+redact('Email: jordan@example.com', { types: ['email'] });
+// 'Email: jo****************'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Returns the text unchanged when no PII of the requested type(s) is found, or when `types` is an empty array.
+- Phone detection reuses `isPhoneNumber`'s scope, so the same limits apply — e.g. a bare 7-digit local number without an area code is not detected, matching `isPhoneNumber('5550173') // false`.
+- Every occurrence of a repeated match is masked, not just the first.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -136,6 +136,19 @@ maskEmail('jordan@example.com'); // 'jo****************'
 maskText('4111111111111234', { visibleEnd: 4 }); // '************1234' (card number, last 4 visible)
 ```
 
+### Redact PII Before Logging User Input
+
+```js
+import { redact } from 'textconvert';
+
+function safeLog(message) {
+  console.log(redact(message));
+}
+
+safeLog('Contact me at jordan@example.com or 555-123-4567');
+// 'Contact me at jo**************** or 55**********'
+```
+
 ---
 
 ## Combining Functions

--- a/src/text/redact.ts
+++ b/src/text/redact.ts
@@ -1,0 +1,97 @@
+import { extractEmails } from './extract';
+import { maskText } from './mask';
+import { isPhoneNumber } from './validation/phoneNumber';
+
+// Characters allowed in a phone number candidate, checked one character at
+// a time (O(1) per check, no regex backtracking risk) rather than with a
+// `+`-quantified regex scanned across the whole string.
+const phoneChars = new Set([...'+0123456789 ().-']);
+
+/**
+ * Finds phone-number-shaped candidate substrings via a single linear pass:
+ * maximal runs of phone-safe characters, trimmed of surrounding whitespace.
+ * Letters and any other character end a run, so ordinary prose naturally
+ * breaks candidates apart.
+ */
+function findPhoneCandidates(text: string): string[] {
+  const candidates: string[] = [];
+  let i = 0;
+
+  while (i < text.length) {
+    if (!phoneChars.has(text[i])) {
+      i++;
+      continue;
+    }
+
+    let end = i;
+    while (end < text.length && phoneChars.has(text[end])) end++;
+
+    let start = i;
+    while (start < end && text[start] === ' ') start++;
+    let trimmedEnd = end;
+    while (trimmedEnd > start && text[trimmedEnd - 1] === ' ') trimmedEnd--;
+
+    if (trimmedEnd > start) candidates.push(text.slice(start, trimmedEnd));
+
+    i = end;
+  }
+
+  return candidates;
+}
+
+// A trailing '.' is ambiguous: it's a valid mid-number separator (as in
+// '555.123.4567') but also commonly a sentence-ending period, which
+// findPhoneCandidates can't otherwise tell apart. Since a phone number
+// never legitimately ends the match on a '.', it's always stripped before
+// validating.
+function stripTrailingDots(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '.') end--;
+  return value.slice(0, end);
+}
+
+/** Phone numbers found in text, validated with {@link isPhoneNumber}. */
+function findPhoneNumbers(text: string): string[] {
+  return findPhoneCandidates(text).map(stripTrailingDots).filter(isPhoneNumber);
+}
+
+/**
+ * Scans free-form text for embedded PII (emails and phone numbers) and
+ * masks each match in place, using {@link extractEmails} to locate emails
+ * and {@link maskText} to mask every match — for sanitizing logs, support
+ * tickets, or user-generated content before storage or display.
+ *
+ * @param text Text to redact.
+ * @param options.types Which PII types to redact. Default is both `'email'` and `'phone'`.
+ * @param options.maskChar Character(s) to use for masked positions, passed through to {@link maskText}. Default is `'*'`.
+ * @returns The text with each detected match masked in place.
+ * @example
+ * redact('Contact me at jordan@example.com or 555-123-4567');
+ * // 'Contact me at jo**************** or 55**********'
+ * redact('Email: jordan@example.com', { types: ['email'] });
+ * // 'Email: jo****************'
+ */
+export function redact(
+  text: string,
+  options: { types?: Array<'email' | 'phone'>; maskChar?: string } = {},
+): string {
+  if (!text) return 'Please provide a valid input text';
+
+  const { types = ['email', 'phone'], maskChar } = options;
+
+  let result = text;
+
+  if (types.includes('email')) {
+    for (const email of new Set(extractEmails(text))) {
+      result = result.split(email).join(maskText(email, { maskChar }));
+    }
+  }
+
+  if (types.includes('phone')) {
+    for (const phone of new Set(findPhoneNumbers(text))) {
+      result = result.split(phone).join(maskText(phone, { maskChar }));
+    }
+  }
+
+  return result;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -6,6 +6,7 @@ import { clear } from './text/clear';
 import { count, countSentences, countWords } from './text/count';
 import { extractEmails, extractUrls } from './text/extract';
 import { maskText } from './text/mask';
+import { redact } from './text/redact';
 import { reverse } from './text/reverse';
 import { spread } from './text/spread';
 import { isEmail } from './text/validation/email';
@@ -34,6 +35,7 @@ export {
   maskText,
   numbersToWords,
   pascalCase,
+  redact,
   reverse,
   slugify,
   snakeCase,

--- a/tests/Text/redact.test.ts
+++ b/tests/Text/redact.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { redact } from '../../src/textConvert';
+
+describe('#redact', () => {
+  it('should mask both an email and a phone number by default', () => {
+    expect(redact('Contact me at jordan@example.com or 555-123-4567')).toBe(
+      'Contact me at jo**************** or 55**********',
+    );
+  });
+
+  it('should redact only the requested type', () => {
+    expect(redact('Email: jordan@example.com', { types: ['email'] })).toBe(
+      'Email: jo****************',
+    );
+    expect(redact('Call 555-123-4567', { types: ['phone'] })).toBe('Call 55**********');
+  });
+
+  it('should leave text unchanged when types is an empty array', () => {
+    expect(redact('jordan@example.com', { types: [] })).toBe('jordan@example.com');
+  });
+
+  it('should support a custom mask character', () => {
+    expect(redact('jordan@example.com', { maskChar: '#' })).toBe('jo################');
+  });
+
+  it('should mask every occurrence of a repeated match', () => {
+    expect(redact('jordan@example.com appears twice: jordan@example.com')).toBe(
+      'jo**************** appears twice: jo****************',
+    );
+  });
+
+  it('should not swallow a trailing sentence period into a phone match', () => {
+    expect(redact('Call (202) 555-0173.', { types: ['phone'] })).toBe('Call (2************.');
+  });
+
+  it('should reject a bare local number without an area code (matches isPhoneNumber)', () => {
+    expect(redact('Room 202, call 555-0173.', { types: ['phone'] })).toBe(
+      'Room 202, call 555-0173.',
+    );
+  });
+
+  it('should not false-positive on unrelated numeric text', () => {
+    expect(redact('Version 2024.03.15 build 10', { types: ['phone'] })).toBe(
+      'Version 2024.03.15 build 10',
+    );
+  });
+
+  it('should handle dotted and international phone formats', () => {
+    expect(redact('555.123.4567 is my number.', { types: ['phone'] })).toBe(
+      '55********** is my number.',
+    );
+    expect(redact('+1-202-555-0173 works too.', { types: ['phone'] })).toBe(
+      '+1************* works too.',
+    );
+  });
+
+  it('should return text unchanged when there is no PII', () => {
+    expect(redact('No PII here.')).toBe('No PII here.');
+  });
+
+  it("should return 'Please provide a valid input text' for empty input", () => {
+    expect(redact('')).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#311`

Adds `redact(text: string, options?: { types?: Array<'email' | 'phone'>; maskChar?: string }): string`, which scans free-form text for embedded PII (emails and phone numbers) and masks each match in place — for sanitizing logs, support tickets, or user-generated content before storage or display.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

_Built on `extractEmails` and `maskText` per the issue's explicit guidance, rather than reimplementing extraction/masking logic. There's no public `extractPhoneNumbers`, so phone detection uses a new private (non-exported) linear-scan candidate finder inside `redact.ts`, validated against `isPhoneNumber` — kept internal since the issue only asked for email/phone detection in `redact`, not a new public phone-extraction API._

_Found and fixed a real edge case while testing against realistic input: a trailing sentence period was getting swallowed into phone matches, e.g. `'Call (202) 555-0173.'` matched `'(202) 555-0173.'` including the period, because `.` is valid mid-number separator syntax (`555.123.4567`) and `isPhoneNumber`'s own regex doesn't distinguish where it appears. Fixed with the same trim-then-validate pattern already used for emails/URLs in `extract.ts` — a trailing `.` is always stripped from a phone candidate before validating, since a phone number never legitimately ends the match on one._

_Also hit a TypeScript build error using `String.prototype.replaceAll` (not in the configured `lib` target) — swapped to the equivalent `split(x).join(y)` rather than touching the project's compile target._

_The masking behavior deliberately doesn't try to be smarter than `maskText`'s own defaults (e.g. keeping an email's domain fully visible, or preserving phone number separator positions) — the issue explicitly says to use `maskText` to mask each match rather than reimplementing masking rules, so the whole matched substring gets masked with `maskText`'s existing default (first 2 characters visible). All examples in the JSDoc/tests are verified against actual output, not hand-counted, after finding character-count mismatches in earlier PRs' hand-written examples._

_Verified ReDoS-safe on adversarial input (500,000 characters resolves in ~54ms) using the same linear-scan, Set-based-character-membership approach established for `extractEmails`/`extractUrls`. Full suite (170 tests), lint, typecheck, and build all pass._

### References

Closes #311.
