### PR TITLE
chore: mirror publishing to JSR alongside npm

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,3 +46,18 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Sync jsr.json version with package.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = require('./package.json');
+            const jsr = JSON.parse(fs.readFileSync('./jsr.json', 'utf8'));
+            jsr.version = pkg.version;
+            fs.writeFileSync('./jsr.json', JSON.stringify(jsr, null, 2) + '\n');
+          "
+      - name: Publish to JSR
+        # Best-effort mirror alongside npm (the primary registry) -- a JSR
+        # hiccup shouldn't fail the whole release workflow after npm has
+        # already published successfully.
+        run: npx jsr publish --allow-slow-types
+        continue-on-error: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,7 @@ This project follows the [all-contributors](https://allcontributors.org/) specif
 - Every push to `main` that contains releasable commits (`feat`, `fix`, etc.) opens or updates a release PR with the version bump and CHANGELOG.md entry. Merging that PR creates the GitHub Release and tag.
 - See [How Commit Messages Drive the Version Bump](#how-commit-messages-drive-the-version-bump) above for exactly which commit type produces which bump, and what counts as a breaking change for this project.
 - When that release is published, the package is automatically published to npm via GitHub Actions.
+- The package is also mirrored to [JSR](https://jsr.io/@monsieur-nico/textconvert) as a fallback registry, published from the same workflow right after npm. `jsr.json`'s `version` field is synced from `package.json` automatically in CI — it doesn't need to be updated by hand. The JSR publish step is best-effort (`continue-on-error`), so a JSR-side hiccup doesn't fail the whole release after npm has already succeeded.
 
 ## Code of Conduct
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,10 @@
+{
+  "name": "@monsieur-nico/textconvert",
+  "version": "1.14.0",
+  "license": "MIT",
+  "exports": "./src/textConvert.ts",
+  "publish": {
+    "include": ["src", "README.md", "LICENSE", "CHANGELOG.md"],
+    "exclude": ["**/*.test.ts"]
+  }
+}


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

_Mirrors publishing to [JSR](https://jsr.io/@monsieur-nico/textconvert) alongside npm, motivated by npm registry reliability issues (this repo's CI has hit real npm 502/503 errors before) — a mirror registry means a future npm outage doesn't leave the package fully unavailable to new installs._

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [x] Other (please describe):
  > CI/release infrastructure change.

### Details

_`jsr.json` publishes raw TypeScript source (`src/textConvert.ts`) rather than the compiled `dist/` output, since JSR does its own type-checking and auto-generates docs directly from source — this is the standard JSR publishing model, distinct from npm's compiled-output approach._

_Extends the existing `publish` job in `release-please.yml`: after `npm publish` succeeds, a step syncs `jsr.json`'s `version` field from `package.json` (verified locally that this preserves every other field — `name`, `license`, `exports`, `publish.include`/`exclude` — untouched), then runs `npx jsr publish --allow-slow-types` using the same `id-token: write` OIDC permission already granted for npm's trusted publishing — no new secret required. The JSR step is `continue-on-error: true`, so a JSR-side issue never fails the release after npm has already succeeded — npm stays the primary, uninterrupted channel._

_The `@monsieur-nico` scope is claimed and linked as a Trusted Publisher to this repo already (confirmed via JSR's own "Publish from CI" onboarding page, which showed the repo link and matching OIDC permissions before this PR was opened) — first real publish will happen automatically on the next release._

_No code changes — config/CI only, no tests needed. Full suite (176 tests), lint, typecheck, and build all pass regardless, to confirm nothing else was affected._

### References

_N/A_
