### PR TITLE
fix!: numbersToWords returns a sentinel string instead of throwing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,135 +1,679 @@
 # textConvert API Reference
 
-Detailed documentation for every function has moved into per-category files under [docs/api/](api/). This page stays in place as a stable index — every anchor below (`docs/API.md#redact`, etc.) still resolves, it just points you one click further to the full spec, parameters, examples, and edge cases.
-
-- [**Case Conversion**](api/case-conversion.md) — [camelCase](#camelcase), [pascalCase](#pascalcase), [snakeCase](#snakecase), [kebabCase](#kebabcase), [slugify](#slugify), [capitalize](#capitalize), [titleCase](#titlecase)
-- [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
-- [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls)
-- [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext)
-- [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
-- [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
-- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
+This document provides detailed documentation for all public functions exported by the textConvert library.
 
 ---
 
-## Case Conversion
+## Table of Contents
 
-### camelCase
-
-Full docs: [docs/api/case-conversion.md#camelcase](api/case-conversion.md#camelcase)
-
-### pascalCase
-
-Full docs: [docs/api/case-conversion.md#pascalcase](api/case-conversion.md#pascalcase)
-
-### snakeCase
-
-Full docs: [docs/api/case-conversion.md#snakecase](api/case-conversion.md#snakecase)
-
-### kebabCase
-
-Full docs: [docs/api/case-conversion.md#kebabcase](api/case-conversion.md#kebabcase)
-
-### slugify
-
-Full docs: [docs/api/case-conversion.md#slugify](api/case-conversion.md#slugify)
-
-### capitalize
-
-Full docs: [docs/api/case-conversion.md#capitalize](api/case-conversion.md#capitalize)
-
-### titleCase
-
-Full docs: [docs/api/case-conversion.md#titlecase](api/case-conversion.md#titlecase)
+- [clear](#clear)
+- [count](#count)
+- [countWords](#countwords)
+- [countSentences](#countsentences)
+- [reverse](#reverse)
+- [spread](#spread)
+- [truncate](#truncate)
+- [maskText](#masktext)
+- [redact](#redact)
+- [camelCase](#camelcase)
+- [pascalCase](#pascalcase)
+- [snakeCase](#snakecase)
+- [kebabCase](#kebabcase)
+- [slugify](#slugify)
+- [capitalize](#capitalize)
+- [titleCase](#titlecase)
+- [getTextStats](#gettextstats)
+- [detectLanguage](#detectlanguage)
+- [numbersToWords](#numberstowords)
+- [isEmail](#isemail)
+- [isUrl](#isurl)
+- [isPhoneNumber](#isphonenumber)
+- [extractEmails](#extractemails)
+- [extractUrls](#extracturls)
 
 ---
 
-## Validation
+## clear
 
-### isEmail
+Removes punctuation from a string and returns a cleaned string.
 
-Full docs: [docs/api/validation.md#isemail](api/validation.md#isemail)
+**Parameters:**
 
-### isUrl
+- `text: string` — The input string to clean.
 
-Full docs: [docs/api/validation.md#isurl](api/validation.md#isurl)
+**Returns:**
 
-### isPhoneNumber
+- `string` — The cleaned string.
 
-Full docs: [docs/api/validation.md#isphonenumber](api/validation.md#isphonenumber)
+**Example:**
 
----
+```js
+clear('Hello, world!'); // 'hello world'
+```
 
-## Extraction
+**Edge Cases:**
 
-### extractEmails
-
-Full docs: [docs/api/extraction.md#extractemails](api/extraction.md#extractemails)
-
-### extractUrls
-
-Full docs: [docs/api/extraction.md#extracturls](api/extraction.md#extracturls)
+- Returns an error message if input is empty.
 
 ---
 
-## Security
+## count
 
-### redact
+Counts the number of letters in a string (optionally including numbers).
 
-Full docs: [docs/api/security.md#redact](api/security.md#redact)
+**Parameters:**
 
-### maskText
+- `text: string` — The input string.
+- `countNumbers?: boolean` — Whether to include numbers (default: false).
 
-Full docs: [docs/api/security.md#masktext](api/security.md#masktext)
+**Returns:**
 
----
+- `number` — The count of letters (and numbers, if specified).
 
-## Text Analysis
+**Example:**
 
-### clear
+```js
+count('Hello, world!'); // 10
+count('Hello0 world', true); // 11
+```
 
-Full docs: [docs/api/text-analysis.md#clear](api/text-analysis.md#clear)
+**Edge Cases:**
 
-### count
-
-Full docs: [docs/api/text-analysis.md#count](api/text-analysis.md#count)
-
-### countWords
-
-Full docs: [docs/api/text-analysis.md#countwords](api/text-analysis.md#countwords)
-
-### countSentences
-
-Full docs: [docs/api/text-analysis.md#countsentences](api/text-analysis.md#countsentences)
-
-### getTextStats
-
-Full docs: [docs/api/text-analysis.md#gettextstats](api/text-analysis.md#gettextstats)
-
-### reverse
-
-Full docs: [docs/api/text-analysis.md#reverse](api/text-analysis.md#reverse)
-
-### spread
-
-Full docs: [docs/api/text-analysis.md#spread](api/text-analysis.md#spread)
-
-### truncate
-
-Full docs: [docs/api/text-analysis.md#truncate](api/text-analysis.md#truncate)
+- Returns 0 for empty input.
 
 ---
 
-## Language
+## countWords
 
-### detectLanguage
+Counts the number of words in a string.
 
-Full docs: [docs/api/language.md#detectlanguage](api/language.md#detectlanguage)
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `number` — The number of words.
+
+**Example:**
+
+```js
+countWords('Hello, world!'); // 2
+```
+
+**Edge Cases:**
+
+- Returns 0 for empty or punctuation-only input.
 
 ---
 
-## Numbers
+## countSentences
 
-### numbersToWords
+Counts the number of sentences in a string.
 
-Full docs: [docs/api/numbers.md#numberstowords](api/numbers.md#numberstowords)
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `number` — The number of sentences.
+
+**Example:**
+
+```js
+countSentences('Hello world! How are you?'); // 2
+```
+
+**Edge Cases:**
+
+- Returns 0 for empty input.
+- Returns 1 if there is text but no sentence-ending punctuation.
+
+---
+
+## reverse
+
+Reverses all characters in a string.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The reversed string.
+
+**Example:**
+
+```js
+reverse('Hello, world!'); // '!dlrow ,olleH'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+
+---
+
+## spread
+
+Returns an array of characters from the provided string (optionally removing punctuation).
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `clear?: boolean` — Whether to remove punctuation (default: false).
+
+**Returns:**
+
+- `string[] | string` — Array of characters or error message.
+
+**Example:**
+
+```js
+spread('Hello, world!'); // ['H', 'e', ...]
+spread('Hello, world!', true); // ['H', 'e', ...]
+```
+
+**Edge Cases:**
+
+- Returns an error message for invalid input type or empty string.
+
+---
+
+## truncate
+
+Shortens text to a maximum length, appending an ellipsis when truncation happens. `maxLength` includes the ellipsis itself.
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `maxLength: number` — Maximum length of the returned string, including the ellipsis.
+- `options?: { ellipsis?: string; byWords?: boolean }` — `ellipsis` overrides the default `'...'`; `byWords` (default `false`) snaps the cut to the last full word instead of cutting mid-word.
+
+**Returns:**
+
+- `string` — The truncated string, or the original string unchanged if it's already within `maxLength`.
+
+**Example:**
+
+```js
+truncate('The quick brown fox jumps over the lazy dog', 20); // 'The quick brown f...'
+truncate('The quick brown fox jumps over the lazy dog', 20, { byWords: true }); // 'The quick brown...'
+truncate('Short text', 20); // 'Short text'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- If `maxLength` is smaller than or equal to the ellipsis length, returns as much of the ellipsis as fits.
+- With `byWords`, falls back to a hard cut if there's no word boundary before the cut point.
+
+---
+
+## camelCase
+
+Converts a string to camelCase.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The camelCase string.
+
+**Example:**
+
+```js
+camelCase('hello world'); // 'helloWorld'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+
+---
+
+## pascalCase
+
+Converts a string to PascalCase.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The PascalCase string.
+
+**Example:**
+
+```js
+pascalCase('hello world'); // 'HelloWorld'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+
+---
+
+## snakeCase
+
+Converts a string to snake_case.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The snake_case string.
+
+**Example:**
+
+```js
+snakeCase('hello world'); // 'hello_world'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+
+---
+
+## kebabCase
+
+Converts a string to kebab-case.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The kebab-case string.
+
+**Example:**
+
+```js
+kebabCase('hello world'); // 'hello-world'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+
+---
+
+## slugify
+
+Converts a string into a URL-safe slug: lowercase, punctuation stripped, separators collapsed to a single `-`, and accented characters normalized to their plain-ASCII equivalents.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The slugified string.
+
+**Example:**
+
+```js
+slugify('Hello, World! 100% Awesome'); // 'hello-world-100-awesome'
+slugify('Café Résumé Review'); // 'cafe-resume-review'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Numbers are preserved (not treated as separators).
+
+---
+
+## capitalize
+
+Capitalizes only the first letter of a string, leaving the rest unchanged.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The string with its first letter capitalized.
+
+**Example:**
+
+```js
+capitalize('hello world'); // 'Hello world'
+capitalize('HELLO WORLD'); // 'HELLO WORLD'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Only the first character is touched — the rest of the string, including existing casing, is left as-is.
+
+---
+
+## titleCase
+
+Capitalizes the first letter of every word, keeping spaces and separators intact — distinct from `pascalCase`, which removes them.
+
+Uses simple every-word capitalization rather than the "small words stay lowercase" (a, an, the, of, ...) style-guide convention — simpler, more predictable, and easier to test, at the cost of not being "typographically correct" by those style guides' rules.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The string with the first letter of every word capitalized.
+
+**Example:**
+
+```js
+titleCase('the lord of the rings'); // 'The Lord Of The Rings'
+titleCase('hello-world_example'); // 'Hello-World_Example'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Digits and separators (spaces, dashes, underscores, etc.) are left untouched — only letter runs are capitalized.
+- A word is any maximal run of letters, so a character like an apostrophe inside a word (`it's`) starts a new "word" on the other side of it (`It'S`), since apostrophes aren't letters.
+
+---
+
+## getTextStats
+
+Analyzes text and returns comprehensive statistics.
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `wordsPerMinute?: number` — Reading speed (default: 200).
+
+**Returns:**
+
+- `TextStatistics` — Object with character, word, sentence counts, averages, and reading time.
+
+**Example:**
+
+```js
+getTextStats('Hello world! This is a test.');
+// {
+//   characterCount: 28,
+//   wordCount: 6,
+//   sentenceCount: 2,
+//   ...
+// }
+```
+
+**Edge Cases:**
+
+- Returns all counts as 0 for empty input.
+
+---
+
+## detectLanguage
+
+Detects the most likely language of a given text.
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `minLength?: number` — Minimum text length for reliable detection (default: 4).
+- `options?: { maxCharsToAnalyze?: number; useCache?: boolean }` — Additional options.
+
+**Returns:**
+
+- `LanguageDetectionResult` — Object with language, confidence, and scores.
+
+**Example:**
+
+```js
+detectLanguage('Bonjour le monde'); // { language: 'French', ... }
+```
+
+**Edge Cases:**
+
+- Returns 'Unknown' for empty or too-short input.
+
+---
+
+## numbersToWords
+
+Converts a non-negative integer below 100 million to English words.
+
+**Parameters:**
+
+- `number: number` — The number to convert.
+
+**Returns:**
+
+- `string` — The number in words, or an error message for invalid input.
+
+**Example:**
+
+```js
+numbersToWords(12345); // 'twelve thousand three hundred and forty-five'
+numbersToWords(-5); // 'Please provide a valid number under 100 million'
+```
+
+**Edge Cases:**
+
+- Returns `'Please provide a valid number under 100 million'` for numbers `>= 100,000,000`, negative numbers, and non-integers — it no longer throws.
+
+---
+
+## isEmail
+
+Validates if a string is a valid email address (RFC 5322).
+
+**Parameters:**
+
+- `text: string` — The string to validate.
+
+**Returns:**
+
+- `boolean` — `true` if valid, `false` otherwise.
+
+**Example:**
+
+```js
+isEmail('user@example.com'); // true
+isEmail('not-an-email'); // false
+```
+
+**Edge Cases:**
+
+- Returns `false` for empty, non-string, or malformed input.
+
+---
+
+## isUrl
+
+Validates if a string is a valid URL.
+
+**Parameters:**
+
+- `text: string` — The string to validate.
+
+**Returns:**
+
+- `boolean` — `true` if valid, `false` otherwise.
+
+**Example:**
+
+```js
+isUrl('https://example.com/path?query=123'); // true
+isUrl('ftp://fileserver'); // false
+isUrl('not a url'); // false
+```
+
+**Edge Cases:**
+
+- Returns `false` for empty input, non-string inputs or wrong protocol/format.
+
+---
+
+## isPhoneNumber
+
+Validates if a string is structurally a valid phone number. This is syntactic validation only — it does not verify that a country calling code is real, that the digit count matches a specific country's numbering plan, or that the number is actually assigned or reachable.
+
+- With a leading `+` (an explicit country code, e.g. E.164): the remaining digits must be between 7 and 15.
+- Without a leading `+` (a bare local number): the digits must be between 10 and 15, since there's no declared country code to trust.
+- Separators (spaces, dashes, dots, parentheses) are allowed and stripped before counting digits.
+
+**Parameters:**
+
+- `text: string` — The string to validate.
+
+**Returns:**
+
+- `boolean` — `true` if valid, `false` otherwise.
+
+**Example:**
+
+```js
+isPhoneNumber('+1-202-555-0173'); // true
+isPhoneNumber('(202) 555 0173'); // true
+isPhoneNumber('5550173'); // false
+```
+
+**Edge Cases:**
+
+- Returns `false` for empty, non-string, or malformed input.
+- Returns `false` for numbers below the international (7-digit) or local (10-digit) floor, or above E.164's 15-digit max.
+- Does not verify the country calling code or the number's real-world validity.
+
+---
+
+## extractEmails
+
+Extracts all email addresses found in a block of text, rather than validating a single string like `isEmail` does. Each candidate is validated with `isEmail` before being included, so results are exactly the substrings that would pass `isEmail`.
+
+**Parameters:**
+
+- `text: string` — The text to search for email addresses.
+
+**Returns:**
+
+- `string[]` — The email addresses found, in the order they appear.
+
+**Example:**
+
+```js
+extractEmails('Contact us at hello@example.com or support@example.org for help.');
+// ['hello@example.com', 'support@example.org']
+```
+
+**Edge Cases:**
+
+- Returns an empty array for empty input or when no valid email is found.
+- Strips trailing sentence punctuation (e.g. a period right after the domain) before validating.
+
+---
+
+## extractUrls
+
+Extracts all URLs found in a block of text, rather than validating a single string like `isUrl` does. Each candidate is validated with `isUrl` before being included, so results are exactly the substrings that would pass `isUrl`.
+
+**Parameters:**
+
+- `text: string` — The text to search for URLs.
+
+**Returns:**
+
+- `string[]` — The URLs found, in the order they appear.
+
+**Example:**
+
+```js
+extractUrls('Check out https://example.com and http://another.example.org/path for details.');
+// ['https://example.com', 'http://another.example.org/path']
+```
+
+**Edge Cases:**
+
+- Returns an empty array for empty input or when no valid URL is found.
+- Only `http://`/`https://` are recognized as URL starts (matching `isUrl`'s scope).
+- Excludes common wrapping delimiters (quotes, angle brackets, parentheses) from the match, and strips trailing sentence punctuation before validating.
+
+---
+
+## maskText
+
+Partially masks a string for display purposes (e.g. showing a masked email or card number in a UI without exposing the full value).
+
+If neither `visibleStart` nor `visibleEnd` is given, the first 2 characters are shown by default. Specifying either one turns off that implicit default for the side you didn't specify — e.g. passing only `visibleEnd` hides the start entirely, rather than also showing the first 2 characters.
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `options.visibleStart?: number` — Number of characters to leave visible at the start.
+- `options.visibleEnd?: number` — Number of characters to leave visible at the end.
+- `options.maskChar?: string` — Character(s) to use for masked positions. Default is `'*'`.
+
+**Returns:**
+
+- `string` — The masked string, or the original string unchanged if the requested visible portions cover the whole string.
+
+**Example:**
+
+```js
+maskText('jordan@example.com'); // 'jo****************'
+maskText('4111111111111234', { visibleEnd: 4 }); // '************1234'
+maskText('secret-token-value', { visibleStart: 0, visibleEnd: 0, maskChar: '#' }); // '##################'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- If the requested visible portions (start + end) cover the whole string, returns the string unchanged rather than over-masking.
+- `visibleStart`/`visibleEnd` are clamped to the string's length, and clamped further so the two visible portions never overlap.
+
+---
+
+## redact
+
+Scans free-form text for embedded PII (emails, phone numbers, credit card numbers) and secrets (API keys/tokens) and masks each match in place, using `extractEmails` to locate emails and `maskText` to mask every match — for sanitizing logs, support tickets, or user-generated content before storage or display.
+
+`redact` is best-effort pattern matching, not a complete PII/secret detector. False negatives are possible — pair it with review for anything where a missed match matters, rather than relying on it as the only safeguard.
+
+**Parameters:**
+
+- `text: string` — The text to redact.
+- `options.types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey'>` — Which types to redact. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'` is opt-in only — see Edge Cases.
+- `options.maskChar?: string` — Character(s) to use for masked positions, passed through to `maskText`. Default is `'*'`.
+
+**Returns:**
+
+- `string` — The text with each detected match masked in place.
+
+**Example:**
+
+```js
+redact('Contact me at jordan@example.com or 555-123-4567');
+// 'Contact me at jo**************** or 55**********'
+redact('Email: jordan@example.com', { types: ['email'] });
+// 'Email: jo****************'
+redact('Card: 4111 1111 1111 1111', { types: ['creditCard'] });
+// 'Card: ***************1111'
+redact('Key: AKIAIOSFODNN7EXAMPLE leaked', { types: ['apiKey'] });
+// 'Key: ******************** leaked'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Returns the text unchanged when no PII of the requested type(s) is found, or when `types` is an empty array.
+- Phone detection reuses `isPhoneNumber`'s scope, so the same limits apply — e.g. a bare 7-digit local number without an area code is not detected, matching `isPhoneNumber('5550173') // false`.
+- Credit card numbers are validated with a Luhn checksum, so an arbitrary 13-19 digit sequence (an order ID, an invoice number) that fails the checksum is not matched. The last 4 digits stay visible in the mask, matching the standard "card ending in 1234" convention.
+- API key/token detection is prefix-based only (AWS `AKIA...`, GitHub `ghp_...`/`github_pat_...`, Stripe `sk_live_...`) — deliberately not entropy-based ("looks like a random string"), which produces heavy false positives on hashes, UUIDs, and ordinary identifiers. Because even prefix-based detection carries more false-positive risk than email/phone/card, `'apiKey'` must be explicitly requested via `types` — it's never included by default.
+- Every occurrence of a repeated match is masked, not just the first.

--- a/docs/api/numbers.md
+++ b/docs/api/numbers.md
@@ -6,7 +6,7 @@
 
 ## numbersToWords
 
-Converts a whole number (below 100 million) to English words.
+Converts a non-negative integer below 100 million to English words.
 
 **Parameters:**
 
@@ -14,7 +14,7 @@ Converts a whole number (below 100 million) to English words.
 
 **Returns:**
 
-- `string` — The number in words.
+- `string` — The number in words, or an error message for invalid input.
 
 **Example:**
 
@@ -23,10 +23,10 @@ import { numbersToWords } from 'textconvert';
 
 numbersToWords(12345); // 'twelve thousand three hundred and forty-five'
 numbersToWords(0); // 'zero'
+numbersToWords(-5); // 'Please provide a valid number under 100 million'
 ```
 
 **Edge Cases:**
 
-- **Throws** a `TypeError`/`Error` for numbers `>= 100,000,000`, rather than returning an error message string — unlike every other function in this library, which returns `'Please provide a valid input text'` (or similar) for invalid input. Wrap calls in `try`/`catch` if the input isn't already validated as under 100 million.
-- **Negative numbers and non-integers are not validated and produce `undefined`, not a sensible result or an error.** `numbersToWords(-5)` and `numbersToWords(12.5)` both return `undefined` — the internal recursion assumes a non-negative integer and simply indexes an array of word-strings with the raw number, which silently fails out-of-bounds instead of throwing. Only pass non-negative integers under 100 million; validate on your side if the input isn't already guaranteed to be one.
+- Returns `'Please provide a valid number under 100 million'` — rather than throwing — for numbers `>= 100,000,000`, negative numbers, and non-integers, matching the sentinel-return convention every other function in this library follows.
 - English only — there's no locale/language parameter.

--- a/src/numbers/numbersToWords.ts
+++ b/src/numbers/numbersToWords.ts
@@ -6,16 +6,19 @@ const numbers: string[] =
 const tens: string[] = 'twenty thirty forty fifty sixty seventy eighty ninety'.split(' ');
 
 /**
- * Get any number below 100 million converted to words.
+ * Get any non-negative integer below 100 million converted to words.
  * @param number Integer input to turn into text.
- * @returns A string of numbers converted to words.
+ * @returns A string of numbers converted to words, or an error message for invalid input.
  * @example
  * numbersToWords(12345); // 'twelve thousand three hundred and forty-five'
+ * numbersToWords(-5); // 'Please provide a valid number under 100 million'
  */
 export function numbersToWords(number: number): string {
-  // Check if the number is less than 100 million
-  if (number >= 100000000) {
-    throw new Error('Please enter a number under 100 million!');
+  // Reject anything that isn't a non-negative integer under 100 million,
+  // matching the sentinel-return convention every other function in this
+  // library follows rather than throwing.
+  if (!Number.isInteger(number) || number < 0 || number >= 100000000) {
+    return 'Please provide a valid number under 100 million';
   }
 
   // Check if the input is between 0-19

--- a/tests/Numbers/numbersToWords.test.ts
+++ b/tests/Numbers/numbersToWords.test.ts
@@ -22,8 +22,14 @@ describe('#numbersToWords', () => {
   it("should return 'ninety-two million' for 92000000", () => {
     expect(numbersToWords(92000000)).toBe('ninety-two million');
   });
-  it('should return Error for 100,000,000', () => {
-    expect(() => numbersToWords(100000000)).toThrow('Please enter a number under 100 million!');
+  it('should return an error message for 100,000,000 instead of throwing', () => {
+    expect(numbersToWords(100000000)).toBe('Please provide a valid number under 100 million');
+  });
+  it('should return an error message for a negative number', () => {
+    expect(numbersToWords(-5)).toBe('Please provide a valid number under 100 million');
+  });
+  it('should return an error message for a non-integer number', () => {
+    expect(numbersToWords(12.5)).toBe('Please provide a valid number under 100 million');
   });
 
   // Adding more test cases to improve coverage


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#330`

`numbersToWords` was the one function in the library that threw a plain `Error` for invalid input, instead of returning a type-appropriate sentinel like every other function does. This picks Direction A from #330: bring `numbersToWords` in line with the existing convention, rather than flipping the whole library to throw (a much larger, separate breaking change).

- `numbersToWords(number >= 100_000_000)` now returns `'Please provide a valid number under 100 million'` instead of throwing.
- Also fixes an unrelated bug found while touching this: negative numbers and non-integers had no validation at all and silently returned `undefined` (e.g. `numbersToWords(-5)` → `undefined`). Both now return the same sentinel string.
- `docs/API.md`'s `numbersToWords` entry updated to match.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

This is a breaking change: anyone with a `try`/`catch` around `numbersToWords` for out-of-range input needs to check the return value instead. Shipped as `fix!:` with a `BREAKING CHANGE:` footer per this repo's own commit conventions.

### References

Closes #330. Part of #328 (v2.0.0 tracking) — direction A was chosen after discussion on #330 to keep this change small and not disturb the sentinel-return convention already documented across the rest of the library.