### PR TITLE
fix: commit jsr.json version sync before publishing to JSR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,6 +55,19 @@ jobs:
             jsr.version = pkg.version;
             fs.writeFileSync('./jsr.json', JSON.stringify(jsr, null, 2) + '\n');
           "
+          # jsr publish refuses to run with uncommitted changes (a genuinely
+          # useful check -- it guarantees what's published matches what's in
+          # version control). Commit the version bump locally, in this
+          # throwaway CI checkout, to satisfy that check honestly instead of
+          # bypassing it with --allow-dirty. Nothing here is pushed back to
+          # the repo -- jsr.json's version is resynced the same way on every
+          # release, so there's nothing to keep.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          VERSION=$(node -p "require('./package.json').version")
+          if ! git diff --quiet -- jsr.json; then
+            git commit -am "chore: sync jsr.json version to $VERSION" --quiet
+          fi
       - name: Publish to JSR
         # Best-effort mirror alongside npm (the primary registry) -- a JSR
         # hiccup shouldn't fail the whole release workflow after npm has


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

The `2.0.0` release published to npm successfully, but never appeared on [JSR](https://jsr.io/@monsieur-nico/textconvert) — the "Publish to JSR" step in `release-please.yml` reported green, but that's because it's `continue-on-error: true`, masking a real failure underneath:

```
M jsr.json
error: Aborting due to uncommitted changes. Check in source code or run with --allow-dirty
Process completed with exit code 1.
```

The "Sync jsr.json version with package.json" step modifies `jsr.json` in place but never committed the change, so `jsr publish` (which refuses to run against an unclean working tree) aborted immediately every time, on every release.

### Fix

Commit the version bump locally within the CI checkout right after syncing it, guarded so it's a no-op if there's nothing to commit (e.g. a re-run). Nothing is pushed back to the repo — `jsr.json`'s version is recomputed the same way on every release, so there's nothing worth keeping in git history.

I deliberately didn't reach for `--allow-dirty` instead: that flag doesn't just excuse this one expected diff, it disables JSR's uncommitted-changes check entirely, for every future release. If a later workflow change ever left some other unintended file modified before this step, `--allow-dirty` would silently let it publish too, with no signal. Committing the expected diff keeps the check meaningful for anything unexpected in the future.

### PR checklist

- [ ] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

CI-workflow-only change, no library code touched. Not a breaking change — `fix:`, no `!`.

Note: this fixes the issue going forward only. `2.0.0` itself won't retroactively appear on JSR (its publish attempt already failed and can't be replayed automatically — JSR's trusted-publishing/OIDC only works from inside GitHub Actions, not from a local machine). The next real release will publish cleanly to both registries.

### References

None — found while investigating why JSR showed no published versions after the `2.0.0` release.