### PR TITLE
feat: add a redact CLI (npx textconvert redact <file>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ redact('Contact me at jordan@example.com or 555-123-4567');
 - [🚀 Getting Started](#-getting-started)
   - [Installation](#installation)
   - [Usage](#usage)
+  - [CLI](#cli)
 - [✨ Features](#-features)
 - [Why Use textConvert?](#why-use-textconvert)
 - [📋 API Reference](#-api-reference)
@@ -75,11 +76,24 @@ import * as convert from 'textconvert';
 const convert = require('textconvert');
 ```
 
+### CLI
+
+A `redact` command is included for sanitizing PII/secrets from the command line — no JS required:
+
+```sh
+npx textconvert redact input.log
+npx textconvert redact input.log --types email,phone --mask-char '#'
+cat input.log | npx textconvert redact > output.log
+```
+
+Reads from the given file, or from stdin if no file is given; always writes to stdout. Run `npx textconvert --help` for the full option list.
+
 ---
 
 ## ✨ Features
 
 - **PII redaction:** mask emails, phone numbers, credit card numbers, and (opt-in) API keys/tokens embedded in free-form text, or partially mask a known value for display
+- **CLI:** `npx textconvert redact <file>` sanitizes a file (or stdin) from the command line, no JS required
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify, capitalize, Title Case
 - Validation: email addresses, URLs, and phone numbers
 - Extraction: pull email addresses and URLs out of a block of text

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,6 +32,9 @@ textConvert/
     numbers/
       numbersToWords.ts # Number to words conversion
     assets/             # Shared regex and constants
+    bin/
+      textconvert.ts    # CLI entry point (thin wiring, built as dist/cli.js)
+    cli.ts              # CLI argument parsing and command logic (testable, no direct IO side effects on import)
     textConvert.ts      # Main entry point (exports all public functions)
   tests/                # Unit and integration tests
   docs/                 # Documentation
@@ -57,6 +60,7 @@ textConvert/
 - **text/extract.ts**: Find every email/URL embedded in a block of text.
 - **numbers/numbersToWords.ts**: Convert numbers to English words.
 - **assets/regex.ts**: Centralized regex patterns for reuse.
+- **bin/textconvert.ts** and **cli.ts**: The `npx textconvert` CLI (currently just `redact`) — `cli.ts` holds the testable argument-parsing/dispatch logic, `bin/textconvert.ts` is the thin entry point that wires it to real `process`/stdio and gets built into `dist/cli.js`. This is the one part of `src/` that legitimately depends on Node built-ins; everything else stays runtime-agnostic by design.
 - **textConvert.ts**: Aggregates and exports all public functions for library consumers.
 
 ---
@@ -95,7 +99,7 @@ textConvert/
 
 - Expanding `detectLanguage`'s supported language set beyond the current seven.
 - More advanced text analytics (e.g. readability scoring).
-- A CLI wrapper for scripting/automation use.
+- More CLI commands beyond `redact`, if there's demand.
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,16 @@ export default [
       },
     },
   },
+  // Node globals for the CLI entry point -- the one legitimate exception to
+  // the rest of src/ staying Node-agnostic by design.
+  {
+    files: ['src/cli.ts', 'src/bin/**/*.ts'],
+    languageOptions: {
+      globals: {
+        process: 'readonly',
+      },
+    },
+  },
   // Override for commitlint.config.js to disable no-undef
   {
     files: ['commitlint.config.js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,16 @@
       "name": "textconvert",
       "version": "2.0.1",
       "license": "MIT",
+      "bin": {
+        "textconvert": "dist/cli.js"
+      },
       "devDependencies": {
         "@commitlint/cli": "^21.2.2",
         "@commitlint/config-conventional": "^21.2.2",
         "@eslint/js": "^10.0.1",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
+        "@types/node": "^22.20.1",
         "@typescript-eslint/eslint-plugin": "^8.69.0",
         "@typescript-eslint/parser": "^8.69.0",
         "@vitest/coverage-v8": "^5.0.0",
@@ -2498,14 +2502,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -5541,12 +5544,11 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "dist/textConvert.js",
   "types": "dist/textConvert.d.ts",
+  "bin": {
+    "textconvert": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/textConvert.d.ts",
@@ -56,7 +59,8 @@
       ],
       "exclude": [
         "**/*.d.ts",
-        "**/*.test.ts"
+        "**/*.test.ts",
+        "src/bin/**"
       ]
     }
   },
@@ -84,7 +88,10 @@
     "phone-validation",
     "phone-number",
     "language-detection",
-    "typescript"
+    "typescript",
+    "cli",
+    "redact",
+    "pii"
   ],
   "author": "Nicolas Alkhoury",
   "license": "MIT",
@@ -98,6 +105,7 @@
     "@eslint/js": "^10.0.1",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
+    "@types/node": "^22.20.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",
     "@typescript-eslint/parser": "^8.69.0",
     "@vitest/coverage-v8": "^5.0.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,4 +19,15 @@ export default [
     plugins: [resolve(), typescript({ tsconfig: './tsconfig.json' })],
     external: [],
   },
+  {
+    input: 'src/bin/textconvert.ts',
+    output: {
+      file: 'dist/cli.js',
+      format: 'esm',
+      banner: '#!/usr/bin/env node',
+      sourcemap: true,
+    },
+    plugins: [resolve(), typescript({ tsconfig: './tsconfig.json' })],
+    external: ['node:fs'],
+  },
 ];

--- a/src/bin/textconvert.ts
+++ b/src/bin/textconvert.ts
@@ -1,0 +1,3 @@
+import { main } from '../cli';
+
+main();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from 'node:fs';
+import { redact } from './text/redact';
+
+const REDACT_TYPES = ['email', 'phone', 'creditCard', 'apiKey'] as const;
+type RedactType = (typeof REDACT_TYPES)[number];
+
+export const HELP_TEXT = `textconvert - CLI for the textconvert library
+
+Usage:
+  textconvert redact [file] [options]
+
+  Sanitizes PII/secrets in a file (or stdin, if no file is given) and
+  prints the result to stdout.
+
+Options:
+  --types <list>       Comma-separated list of what to redact:
+                        email,phone,creditCard,apiKey
+                        (default: email,phone,creditCard)
+  --mask-char <char>    Character(s) used for masked positions (default: *)
+  -h, --help            Show this help message
+
+Examples:
+  textconvert redact input.log
+  textconvert redact input.log --types email,phone
+  cat input.log | textconvert redact --mask-char '#' > output.log
+`;
+
+export class CliArgError extends Error {}
+
+export type ParsedArgs =
+  | { command: 'help' }
+  | { command: 'redact'; file?: string; types?: RedactType[]; maskChar?: string };
+
+function isRedactType(value: string): value is RedactType {
+  return (REDACT_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Parses CLI arguments (already stripped of `node`/script path, i.e.
+ * `process.argv.slice(2)`) into a structured command, or throws
+ * {@link CliArgError} with a message ready to print to stderr.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+    return { command: 'help' };
+  }
+
+  const [command, ...rest] = argv;
+
+  if (command !== 'redact') {
+    throw new CliArgError(`Unknown command: "${command}". Only "redact" is currently supported.`);
+  }
+
+  let file: string | undefined;
+  let types: RedactType[] | undefined;
+  let maskChar: string | undefined;
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+
+    if (arg === '-h' || arg === '--help') {
+      return { command: 'help' };
+    }
+
+    if (arg === '--types') {
+      const value = rest[++i];
+      if (!value) throw new CliArgError('--types requires a value');
+
+      types = value.split(',').map((rawType) => {
+        const trimmed = rawType.trim();
+        if (!isRedactType(trimmed)) {
+          throw new CliArgError(
+            `Invalid --types value: "${trimmed}". Must be one of: ${REDACT_TYPES.join(', ')}`,
+          );
+        }
+        return trimmed;
+      });
+      continue;
+    }
+
+    if (arg === '--mask-char') {
+      const value = rest[++i];
+      if (value === undefined) throw new CliArgError('--mask-char requires a value');
+      maskChar = value;
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      throw new CliArgError(`Unknown option: "${arg}"`);
+    }
+
+    if (file !== undefined) {
+      throw new CliArgError(`Unexpected argument: "${arg}"`);
+    }
+
+    file = arg;
+  }
+
+  return { command: 'redact', file, types, maskChar };
+}
+
+/** Reads the given file, or stdin (fd 0) when no file path is given. */
+export function readInput(file?: string): string {
+  return readFileSync(file ?? 0, 'utf8');
+}
+
+export function runRedact(
+  input: string,
+  options: { types?: RedactType[]; maskChar?: string },
+): string {
+  return redact(input, options);
+}
+
+/**
+ * Entry point wiring real process.argv/stdin/stdout/stderr to the pure
+ * functions above. Kept separate from those functions (and never called
+ * automatically on import) so tests can exercise the parsing/redaction
+ * logic directly without touching real IO.
+ */
+export function main(): void {
+  try {
+    const parsed = parseArgs(process.argv.slice(2));
+
+    if (parsed.command === 'help') {
+      process.stdout.write(HELP_TEXT);
+      return;
+    }
+
+    const input = readInput(parsed.file);
+    const output = runRedact(input, { types: parsed.types, maskChar: parsed.maskChar });
+    process.stdout.write(output);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tests/Cli/cli.test.ts
+++ b/tests/Cli/cli.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CliArgError, HELP_TEXT, main, parseArgs, readInput, runRedact } from '../../src/cli';
+
+describe('#parseArgs', () => {
+  it('returns the help command for no arguments', () => {
+    expect(parseArgs([])).toEqual({ command: 'help' });
+  });
+
+  it('returns the help command for -h/--help', () => {
+    expect(parseArgs(['-h'])).toEqual({ command: 'help' });
+    expect(parseArgs(['--help'])).toEqual({ command: 'help' });
+  });
+
+  it('throws for an unknown command', () => {
+    expect(() => parseArgs(['sluggify'])).toThrow(CliArgError);
+  });
+
+  it('parses a bare redact command with no file (stdin)', () => {
+    expect(parseArgs(['redact'])).toEqual({
+      command: 'redact',
+      file: undefined,
+      types: undefined,
+      maskChar: undefined,
+    });
+  });
+
+  it('parses a redact command with a file argument', () => {
+    expect(parseArgs(['redact', 'input.log'])).toEqual({
+      command: 'redact',
+      file: 'input.log',
+      types: undefined,
+      maskChar: undefined,
+    });
+  });
+
+  it('parses --types as a comma-separated list', () => {
+    const result = parseArgs(['redact', 'input.log', '--types', 'email,phone']);
+    expect(result).toEqual({
+      command: 'redact',
+      file: 'input.log',
+      types: ['email', 'phone'],
+      maskChar: undefined,
+    });
+  });
+
+  it('trims whitespace around --types entries', () => {
+    const result = parseArgs(['redact', '--types', 'email, phone']);
+    expect(result).toMatchObject({ types: ['email', 'phone'] });
+  });
+
+  it('throws for an invalid --types value', () => {
+    expect(() => parseArgs(['redact', '--types', 'ssn'])).toThrow(CliArgError);
+  });
+
+  it('throws when --types has no value', () => {
+    expect(() => parseArgs(['redact', '--types'])).toThrow(CliArgError);
+  });
+
+  it('parses --mask-char', () => {
+    const result = parseArgs(['redact', 'input.log', '--mask-char', '#']);
+    expect(result).toMatchObject({ maskChar: '#' });
+  });
+
+  it('throws when --mask-char has no value', () => {
+    expect(() => parseArgs(['redact', '--mask-char'])).toThrow(CliArgError);
+  });
+
+  it('returns the help command when -h/--help appears after redact', () => {
+    expect(parseArgs(['redact', '--help'])).toEqual({ command: 'help' });
+  });
+
+  it('throws for an unknown option', () => {
+    expect(() => parseArgs(['redact', '--bogus'])).toThrow(CliArgError);
+  });
+
+  it('throws for more than one positional argument', () => {
+    expect(() => parseArgs(['redact', 'a.log', 'b.log'])).toThrow(CliArgError);
+  });
+});
+
+describe('#runRedact', () => {
+  it('redacts using the given options, delegating to redact()', () => {
+    expect(runRedact('Contact me at jordan@example.com', {})).toBe(
+      'Contact me at jo****************',
+    );
+  });
+
+  it('respects a types filter', () => {
+    expect(runRedact('Card: 4111 1111 1111 1111', { types: ['creditCard'] })).toBe(
+      'Card: ***************1111',
+    );
+  });
+});
+
+describe('#readInput', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'textconvert-cli-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads the given file', () => {
+    const file = join(dir, 'input.log');
+    writeFileSync(file, 'hello@example.com');
+    expect(readInput(file)).toBe('hello@example.com');
+  });
+
+  it('throws for a missing file', () => {
+    expect(() => readInput(join(dir, 'missing.log'))).toThrow();
+  });
+});
+
+describe('#main', () => {
+  let dir: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'textconvert-cli-'));
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    process.argv = originalArgv;
+    process.exitCode = undefined;
+  });
+
+  it('prints help text and writes nothing to stderr when called with no arguments', () => {
+    process.argv = ['node', 'textconvert'];
+    main();
+    expect(stdoutSpy).toHaveBeenCalledWith(HELP_TEXT);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('redacts a file and writes the result to stdout', () => {
+    const file = join(dir, 'input.log');
+    writeFileSync(file, 'Contact me at jordan@example.com');
+    process.argv = ['node', 'textconvert', 'redact', file];
+
+    main();
+
+    expect(stdoutSpy).toHaveBeenCalledWith('Contact me at jo****************');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('sets a non-zero exit code and writes to stderr for a missing file', () => {
+    process.argv = ['node', 'textconvert', 'redact', join(dir, 'missing.log')];
+
+    main();
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('sets a non-zero exit code for invalid arguments', () => {
+    process.argv = ['node', 'textconvert', 'redact', '--types', 'bogus'];
+
+    main();
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#322`

Adds a thin CLI wrapper over `redact()` so PII/secrets in a file (or stdin) can be sanitized from the command line without writing JS:

```sh
npx textconvert redact input.log
npx textconvert redact input.log --types email,phone --mask-char '#'
cat input.log | npx textconvert redact > output.log
```

### Scope decisions (per #322's open questions)

- `redact` is the only v1 command, per the issue's own scoping — the other functions operate on a single string, where a CLI barely beats a one-liner; not compelling enough to build speculatively.
- Bundled in this package via a `bin` entry rather than a separate `textconvert-cli` package — avoids a second repo/release pipeline for what's currently a single command.
- Both a file argument and stdin are supported (matching standard Unix tool conventions); output always goes to stdout.
- No argument-parsing dependency (no commander/yargs) — the surface is small, and this would otherwise be the library's first-ever runtime dependency, undermining its dependency-free pitch.

### Implementation

Split into `src/cli.ts` (pure argument-parsing/dispatch logic, unit-tested directly, no IO side effects on import) and `src/bin/textconvert.ts` (thin entry point wiring real `process`/stdio to it, built as `dist/cli.js` via a new Rollup output target). This is the one part of `src/` that legitimately touches Node built-ins — the ESLint config's Node-globals override is scoped to just these two files so the rest of the library stays runtime-agnostic, per `docs/ARCHITECTURE.md`'s existing design principles (also refreshed to reflect the new files).

Also adds `@types/node` as an explicit devDependency, pinned to the `engines.node` major (`>=22`). It was previously only present by incidental hoisting from another package's transitive dependency tree — local typechecking happened to pass despite no declared dependency actually providing it, which is fragile (worked by luck of `node_modules` state, not guaranteed on a fresh install or in an editor's TS server).

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

Verified end-to-end against the actual built `dist/cli.js`: `--help`, file-argument redaction, stdin piping, and the missing-file error path (correct message on stderr, exit code 1) all behave as expected.

### References

Closes #322.