### PR TITLE
feat: add isPalindrome(text) function

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify, capitalize, Title Case
 - Validation: email addresses, URLs, and phone numbers
 - Extraction: pull email addresses and URLs out of a block of text
-- Text analysis: word/letter/sentence/paragraph counting, reading time, etc.
+- Text analysis: word/letter/sentence/paragraph counting, reading time, palindrome checking, etc.
 - Text utilities: truncate with word-boundary awareness
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
@@ -137,6 +137,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `maskText(text, options?)`                   | Partially mask a string for display                   |
 | `redact(text, options?)`                     | Mask PII/secrets embedded in text                     |
 | `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time) |
+| `isPalindrome(text)`                         | Check if text is a palindrome                         |
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |
 | `isEmail(text)`                              | Validate an email address                             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
 - [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls)
 - [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext)
-- [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
+- [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
 
@@ -105,6 +105,10 @@ Full docs: [docs/api/text-analysis.md#countsentences](api/text-analysis.md#count
 ### getTextStats
 
 Full docs: [docs/api/text-analysis.md#gettextstats](api/text-analysis.md#gettextstats)
+
+### isPalindrome
+
+Full docs: [docs/api/text-analysis.md#ispalindrome](api/text-analysis.md#ispalindrome)
 
 ### reverse
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,679 +1,135 @@
 # textConvert API Reference
 
-This document provides detailed documentation for all public functions exported by the textConvert library.
+Detailed documentation for every function has moved into per-category files under [docs/api/](api/). This page stays in place as a stable index — every anchor below (`docs/API.md#redact`, etc.) still resolves, it just points you one click further to the full spec, parameters, examples, and edge cases.
+
+- [**Case Conversion**](api/case-conversion.md) — [camelCase](#camelcase), [pascalCase](#pascalcase), [snakeCase](#snakecase), [kebabCase](#kebabcase), [slugify](#slugify), [capitalize](#capitalize), [titleCase](#titlecase)
+- [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
+- [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls)
+- [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext)
+- [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
+- [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
+- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
 
 ---
 
-## Table of Contents
+## Case Conversion
 
-- [clear](#clear)
-- [count](#count)
-- [countWords](#countwords)
-- [countSentences](#countsentences)
-- [reverse](#reverse)
-- [spread](#spread)
-- [truncate](#truncate)
-- [maskText](#masktext)
-- [redact](#redact)
-- [camelCase](#camelcase)
-- [pascalCase](#pascalcase)
-- [snakeCase](#snakecase)
-- [kebabCase](#kebabcase)
-- [slugify](#slugify)
-- [capitalize](#capitalize)
-- [titleCase](#titlecase)
-- [getTextStats](#gettextstats)
-- [detectLanguage](#detectlanguage)
-- [numbersToWords](#numberstowords)
-- [isEmail](#isemail)
-- [isUrl](#isurl)
-- [isPhoneNumber](#isphonenumber)
-- [extractEmails](#extractemails)
-- [extractUrls](#extracturls)
+### camelCase
 
----
+Full docs: [docs/api/case-conversion.md#camelcase](api/case-conversion.md#camelcase)
 
-## clear
+### pascalCase
 
-Removes punctuation from a string and returns a cleaned string.
+Full docs: [docs/api/case-conversion.md#pascalcase](api/case-conversion.md#pascalcase)
 
-**Parameters:**
+### snakeCase
 
-- `text: string` — The input string to clean.
+Full docs: [docs/api/case-conversion.md#snakecase](api/case-conversion.md#snakecase)
 
-**Returns:**
+### kebabCase
 
-- `string` — The cleaned string.
+Full docs: [docs/api/case-conversion.md#kebabcase](api/case-conversion.md#kebabcase)
 
-**Example:**
+### slugify
 
-```js
-clear('Hello, world!'); // 'hello world'
-```
+Full docs: [docs/api/case-conversion.md#slugify](api/case-conversion.md#slugify)
 
-**Edge Cases:**
+### capitalize
 
-- Returns an error message if input is empty.
+Full docs: [docs/api/case-conversion.md#capitalize](api/case-conversion.md#capitalize)
+
+### titleCase
+
+Full docs: [docs/api/case-conversion.md#titlecase](api/case-conversion.md#titlecase)
 
 ---
 
-## count
+## Validation
 
-Counts the number of letters in a string (optionally including numbers).
+### isEmail
 
-**Parameters:**
+Full docs: [docs/api/validation.md#isemail](api/validation.md#isemail)
 
-- `text: string` — The input string.
-- `countNumbers?: boolean` — Whether to include numbers (default: false).
+### isUrl
 
-**Returns:**
+Full docs: [docs/api/validation.md#isurl](api/validation.md#isurl)
 
-- `number` — The count of letters (and numbers, if specified).
+### isPhoneNumber
 
-**Example:**
-
-```js
-count('Hello, world!'); // 10
-count('Hello0 world', true); // 11
-```
-
-**Edge Cases:**
-
-- Returns 0 for empty input.
+Full docs: [docs/api/validation.md#isphonenumber](api/validation.md#isphonenumber)
 
 ---
 
-## countWords
+## Extraction
 
-Counts the number of words in a string.
+### extractEmails
 
-**Parameters:**
+Full docs: [docs/api/extraction.md#extractemails](api/extraction.md#extractemails)
 
-- `text: string` — The input string.
+### extractUrls
 
-**Returns:**
-
-- `number` — The number of words.
-
-**Example:**
-
-```js
-countWords('Hello, world!'); // 2
-```
-
-**Edge Cases:**
-
-- Returns 0 for empty or punctuation-only input.
+Full docs: [docs/api/extraction.md#extracturls](api/extraction.md#extracturls)
 
 ---
 
-## countSentences
+## Security
 
-Counts the number of sentences in a string.
+### redact
 
-**Parameters:**
+Full docs: [docs/api/security.md#redact](api/security.md#redact)
 
-- `text: string` — The input string.
+### maskText
 
-**Returns:**
-
-- `number` — The number of sentences.
-
-**Example:**
-
-```js
-countSentences('Hello world! How are you?'); // 2
-```
-
-**Edge Cases:**
-
-- Returns 0 for empty input.
-- Returns 1 if there is text but no sentence-ending punctuation.
+Full docs: [docs/api/security.md#masktext](api/security.md#masktext)
 
 ---
 
-## reverse
+## Text Analysis
 
-Reverses all characters in a string.
+### clear
 
-**Parameters:**
+Full docs: [docs/api/text-analysis.md#clear](api/text-analysis.md#clear)
 
-- `text: string` — The input string.
+### count
 
-**Returns:**
+Full docs: [docs/api/text-analysis.md#count](api/text-analysis.md#count)
 
-- `string` — The reversed string.
+### countWords
 
-**Example:**
+Full docs: [docs/api/text-analysis.md#countwords](api/text-analysis.md#countwords)
 
-```js
-reverse('Hello, world!'); // '!dlrow ,olleH'
-```
+### countSentences
 
-**Edge Cases:**
+Full docs: [docs/api/text-analysis.md#countsentences](api/text-analysis.md#countsentences)
 
-- Returns an error message for empty input.
+### getTextStats
 
----
+Full docs: [docs/api/text-analysis.md#gettextstats](api/text-analysis.md#gettextstats)
 
-## spread
+### reverse
 
-Returns an array of characters from the provided string (optionally removing punctuation).
+Full docs: [docs/api/text-analysis.md#reverse](api/text-analysis.md#reverse)
 
-**Parameters:**
+### spread
 
-- `text: string` — The input string.
-- `clear?: boolean` — Whether to remove punctuation (default: false).
+Full docs: [docs/api/text-analysis.md#spread](api/text-analysis.md#spread)
 
-**Returns:**
+### truncate
 
-- `string[] | string` — Array of characters or error message.
-
-**Example:**
-
-```js
-spread('Hello, world!'); // ['H', 'e', ...]
-spread('Hello, world!', true); // ['H', 'e', ...]
-```
-
-**Edge Cases:**
-
-- Returns an error message for invalid input type or empty string.
+Full docs: [docs/api/text-analysis.md#truncate](api/text-analysis.md#truncate)
 
 ---
 
-## truncate
+## Language
 
-Shortens text to a maximum length, appending an ellipsis when truncation happens. `maxLength` includes the ellipsis itself.
+### detectLanguage
 
-**Parameters:**
-
-- `text: string` — The input string.
-- `maxLength: number` — Maximum length of the returned string, including the ellipsis.
-- `options?: { ellipsis?: string; byWords?: boolean }` — `ellipsis` overrides the default `'...'`; `byWords` (default `false`) snaps the cut to the last full word instead of cutting mid-word.
-
-**Returns:**
-
-- `string` — The truncated string, or the original string unchanged if it's already within `maxLength`.
-
-**Example:**
-
-```js
-truncate('The quick brown fox jumps over the lazy dog', 20); // 'The quick brown f...'
-truncate('The quick brown fox jumps over the lazy dog', 20, { byWords: true }); // 'The quick brown...'
-truncate('Short text', 20); // 'Short text'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-- If `maxLength` is smaller than or equal to the ellipsis length, returns as much of the ellipsis as fits.
-- With `byWords`, falls back to a hard cut if there's no word boundary before the cut point.
+Full docs: [docs/api/language.md#detectlanguage](api/language.md#detectlanguage)
 
 ---
 
-## camelCase
+## Numbers
 
-Converts a string to camelCase.
+### numbersToWords
 
-**Parameters:**
-
-- `text: string` — The input string.
-
-**Returns:**
-
-- `string` — The camelCase string.
-
-**Example:**
-
-```js
-camelCase('hello world'); // 'helloWorld'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-
----
-
-## pascalCase
-
-Converts a string to PascalCase.
-
-**Parameters:**
-
-- `text: string` — The input string.
-
-**Returns:**
-
-- `string` — The PascalCase string.
-
-**Example:**
-
-```js
-pascalCase('hello world'); // 'HelloWorld'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-
----
-
-## snakeCase
-
-Converts a string to snake_case.
-
-**Parameters:**
-
-- `text: string` — The input string.
-
-**Returns:**
-
-- `string` — The snake_case string.
-
-**Example:**
-
-```js
-snakeCase('hello world'); // 'hello_world'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-
----
-
-## kebabCase
-
-Converts a string to kebab-case.
-
-**Parameters:**
-
-- `text: string` — The input string.
-
-**Returns:**
-
-- `string` — The kebab-case string.
-
-**Example:**
-
-```js
-kebabCase('hello world'); // 'hello-world'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-
----
-
-## slugify
-
-Converts a string into a URL-safe slug: lowercase, punctuation stripped, separators collapsed to a single `-`, and accented characters normalized to their plain-ASCII equivalents.
-
-**Parameters:**
-
-- `text: string` — The input string.
-
-**Returns:**
-
-- `string` — The slugified string.
-
-**Example:**
-
-```js
-slugify('Hello, World! 100% Awesome'); // 'hello-world-100-awesome'
-slugify('Café Résumé Review'); // 'cafe-resume-review'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-- Numbers are preserved (not treated as separators).
-
----
-
-## capitalize
-
-Capitalizes only the first letter of a string, leaving the rest unchanged.
-
-**Parameters:**
-
-- `text: string` — The input string.
-
-**Returns:**
-
-- `string` — The string with its first letter capitalized.
-
-**Example:**
-
-```js
-capitalize('hello world'); // 'Hello world'
-capitalize('HELLO WORLD'); // 'HELLO WORLD'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-- Only the first character is touched — the rest of the string, including existing casing, is left as-is.
-
----
-
-## titleCase
-
-Capitalizes the first letter of every word, keeping spaces and separators intact — distinct from `pascalCase`, which removes them.
-
-Uses simple every-word capitalization rather than the "small words stay lowercase" (a, an, the, of, ...) style-guide convention — simpler, more predictable, and easier to test, at the cost of not being "typographically correct" by those style guides' rules.
-
-**Parameters:**
-
-- `text: string` — The input string.
-
-**Returns:**
-
-- `string` — The string with the first letter of every word capitalized.
-
-**Example:**
-
-```js
-titleCase('the lord of the rings'); // 'The Lord Of The Rings'
-titleCase('hello-world_example'); // 'Hello-World_Example'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-- Digits and separators (spaces, dashes, underscores, etc.) are left untouched — only letter runs are capitalized.
-- A word is any maximal run of letters, so a character like an apostrophe inside a word (`it's`) starts a new "word" on the other side of it (`It'S`), since apostrophes aren't letters.
-
----
-
-## getTextStats
-
-Analyzes text and returns comprehensive statistics.
-
-**Parameters:**
-
-- `text: string` — The input string.
-- `wordsPerMinute?: number` — Reading speed (default: 200).
-
-**Returns:**
-
-- `TextStatistics` — Object with character, word, sentence counts, averages, and reading time.
-
-**Example:**
-
-```js
-getTextStats('Hello world! This is a test.');
-// {
-//   characterCount: 28,
-//   wordCount: 6,
-//   sentenceCount: 2,
-//   ...
-// }
-```
-
-**Edge Cases:**
-
-- Returns all counts as 0 for empty input.
-
----
-
-## detectLanguage
-
-Detects the most likely language of a given text.
-
-**Parameters:**
-
-- `text: string` — The input string.
-- `minLength?: number` — Minimum text length for reliable detection (default: 4).
-- `options?: { maxCharsToAnalyze?: number; useCache?: boolean }` — Additional options.
-
-**Returns:**
-
-- `LanguageDetectionResult` — Object with language, confidence, and scores.
-
-**Example:**
-
-```js
-detectLanguage('Bonjour le monde'); // { language: 'French', ... }
-```
-
-**Edge Cases:**
-
-- Returns 'Unknown' for empty or too-short input.
-
----
-
-## numbersToWords
-
-Converts a non-negative integer below 100 million to English words.
-
-**Parameters:**
-
-- `number: number` — The number to convert.
-
-**Returns:**
-
-- `string` — The number in words, or an error message for invalid input.
-
-**Example:**
-
-```js
-numbersToWords(12345); // 'twelve thousand three hundred and forty-five'
-numbersToWords(-5); // 'Please provide a valid number under 100 million'
-```
-
-**Edge Cases:**
-
-- Returns `'Please provide a valid number under 100 million'` for numbers `>= 100,000,000`, negative numbers, and non-integers — it no longer throws.
-
----
-
-## isEmail
-
-Validates if a string is a valid email address (RFC 5322).
-
-**Parameters:**
-
-- `text: string` — The string to validate.
-
-**Returns:**
-
-- `boolean` — `true` if valid, `false` otherwise.
-
-**Example:**
-
-```js
-isEmail('user@example.com'); // true
-isEmail('not-an-email'); // false
-```
-
-**Edge Cases:**
-
-- Returns `false` for empty, non-string, or malformed input.
-
----
-
-## isUrl
-
-Validates if a string is a valid URL.
-
-**Parameters:**
-
-- `text: string` — The string to validate.
-
-**Returns:**
-
-- `boolean` — `true` if valid, `false` otherwise.
-
-**Example:**
-
-```js
-isUrl('https://example.com/path?query=123'); // true
-isUrl('ftp://fileserver'); // false
-isUrl('not a url'); // false
-```
-
-**Edge Cases:**
-
-- Returns `false` for empty input, non-string inputs or wrong protocol/format.
-
----
-
-## isPhoneNumber
-
-Validates if a string is structurally a valid phone number. This is syntactic validation only — it does not verify that a country calling code is real, that the digit count matches a specific country's numbering plan, or that the number is actually assigned or reachable.
-
-- With a leading `+` (an explicit country code, e.g. E.164): the remaining digits must be between 7 and 15.
-- Without a leading `+` (a bare local number): the digits must be between 10 and 15, since there's no declared country code to trust.
-- Separators (spaces, dashes, dots, parentheses) are allowed and stripped before counting digits.
-
-**Parameters:**
-
-- `text: string` — The string to validate.
-
-**Returns:**
-
-- `boolean` — `true` if valid, `false` otherwise.
-
-**Example:**
-
-```js
-isPhoneNumber('+1-202-555-0173'); // true
-isPhoneNumber('(202) 555 0173'); // true
-isPhoneNumber('5550173'); // false
-```
-
-**Edge Cases:**
-
-- Returns `false` for empty, non-string, or malformed input.
-- Returns `false` for numbers below the international (7-digit) or local (10-digit) floor, or above E.164's 15-digit max.
-- Does not verify the country calling code or the number's real-world validity.
-
----
-
-## extractEmails
-
-Extracts all email addresses found in a block of text, rather than validating a single string like `isEmail` does. Each candidate is validated with `isEmail` before being included, so results are exactly the substrings that would pass `isEmail`.
-
-**Parameters:**
-
-- `text: string` — The text to search for email addresses.
-
-**Returns:**
-
-- `string[]` — The email addresses found, in the order they appear.
-
-**Example:**
-
-```js
-extractEmails('Contact us at hello@example.com or support@example.org for help.');
-// ['hello@example.com', 'support@example.org']
-```
-
-**Edge Cases:**
-
-- Returns an empty array for empty input or when no valid email is found.
-- Strips trailing sentence punctuation (e.g. a period right after the domain) before validating.
-
----
-
-## extractUrls
-
-Extracts all URLs found in a block of text, rather than validating a single string like `isUrl` does. Each candidate is validated with `isUrl` before being included, so results are exactly the substrings that would pass `isUrl`.
-
-**Parameters:**
-
-- `text: string` — The text to search for URLs.
-
-**Returns:**
-
-- `string[]` — The URLs found, in the order they appear.
-
-**Example:**
-
-```js
-extractUrls('Check out https://example.com and http://another.example.org/path for details.');
-// ['https://example.com', 'http://another.example.org/path']
-```
-
-**Edge Cases:**
-
-- Returns an empty array for empty input or when no valid URL is found.
-- Only `http://`/`https://` are recognized as URL starts (matching `isUrl`'s scope).
-- Excludes common wrapping delimiters (quotes, angle brackets, parentheses) from the match, and strips trailing sentence punctuation before validating.
-
----
-
-## maskText
-
-Partially masks a string for display purposes (e.g. showing a masked email or card number in a UI without exposing the full value).
-
-If neither `visibleStart` nor `visibleEnd` is given, the first 2 characters are shown by default. Specifying either one turns off that implicit default for the side you didn't specify — e.g. passing only `visibleEnd` hides the start entirely, rather than also showing the first 2 characters.
-
-**Parameters:**
-
-- `text: string` — The input string.
-- `options.visibleStart?: number` — Number of characters to leave visible at the start.
-- `options.visibleEnd?: number` — Number of characters to leave visible at the end.
-- `options.maskChar?: string` — Character(s) to use for masked positions. Default is `'*'`.
-
-**Returns:**
-
-- `string` — The masked string, or the original string unchanged if the requested visible portions cover the whole string.
-
-**Example:**
-
-```js
-maskText('jordan@example.com'); // 'jo****************'
-maskText('4111111111111234', { visibleEnd: 4 }); // '************1234'
-maskText('secret-token-value', { visibleStart: 0, visibleEnd: 0, maskChar: '#' }); // '##################'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-- If the requested visible portions (start + end) cover the whole string, returns the string unchanged rather than over-masking.
-- `visibleStart`/`visibleEnd` are clamped to the string's length, and clamped further so the two visible portions never overlap.
-
----
-
-## redact
-
-Scans free-form text for embedded PII (emails, phone numbers, credit card numbers) and secrets (API keys/tokens) and masks each match in place, using `extractEmails` to locate emails and `maskText` to mask every match — for sanitizing logs, support tickets, or user-generated content before storage or display.
-
-`redact` is best-effort pattern matching, not a complete PII/secret detector. False negatives are possible — pair it with review for anything where a missed match matters, rather than relying on it as the only safeguard.
-
-**Parameters:**
-
-- `text: string` — The text to redact.
-- `options.types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey'>` — Which types to redact. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'` is opt-in only — see Edge Cases.
-- `options.maskChar?: string` — Character(s) to use for masked positions, passed through to `maskText`. Default is `'*'`.
-
-**Returns:**
-
-- `string` — The text with each detected match masked in place.
-
-**Example:**
-
-```js
-redact('Contact me at jordan@example.com or 555-123-4567');
-// 'Contact me at jo**************** or 55**********'
-redact('Email: jordan@example.com', { types: ['email'] });
-// 'Email: jo****************'
-redact('Card: 4111 1111 1111 1111', { types: ['creditCard'] });
-// 'Card: ***************1111'
-redact('Key: AKIAIOSFODNN7EXAMPLE leaked', { types: ['apiKey'] });
-// 'Key: ******************** leaked'
-```
-
-**Edge Cases:**
-
-- Returns an error message for empty input.
-- Returns the text unchanged when no PII of the requested type(s) is found, or when `types` is an empty array.
-- Phone detection reuses `isPhoneNumber`'s scope, so the same limits apply — e.g. a bare 7-digit local number without an area code is not detected, matching `isPhoneNumber('5550173') // false`.
-- Credit card numbers are validated with a Luhn checksum, so an arbitrary 13-19 digit sequence (an order ID, an invoice number) that fails the checksum is not matched. The last 4 digits stay visible in the mask, matching the standard "card ending in 1234" convention.
-- API key/token detection is prefix-based only (AWS `AKIA...`, GitHub `ghp_...`/`github_pat_...`, Stripe `sk_live_...`) — deliberately not entropy-based ("looks like a random string"), which produces heavy false positives on hashes, UUIDs, and ordinary identifiers. Because even prefix-based detection carries more false-positive risk than email/phone/card, `'apiKey'` must be explicitly requested via `types` — it's never included by default.
-- Every occurrence of a repeated match is masked, not just the first.
+Full docs: [docs/api/numbers.md#numberstowords](api/numbers.md#numberstowords)

--- a/docs/api/text-analysis.md
+++ b/docs/api/text-analysis.md
@@ -1,6 +1,6 @@
 # Text Analysis
 
-`clear`, `count`, `countWords`, `countSentences`, `getTextStats`, `reverse`, `spread`, `truncate`.
+`clear`, `count`, `countWords`, `countSentences`, `getTextStats`, `isPalindrome`, `reverse`, `spread`, `truncate`.
 
 ---
 
@@ -11,6 +11,7 @@
 - [countWords](#countwords)
 - [countSentences](#countsentences)
 - [getTextStats](#gettextstats)
+- [isPalindrome](#ispalindrome)
 - [reverse](#reverse)
 - [spread](#spread)
 - [truncate](#truncate)
@@ -186,6 +187,37 @@ getTextStats('Hello world! This is a test.');
 - Returns all numeric fields as 0 and `readingTimeFormatted: '0 sec'` for empty (or whitespace-only) input.
 - `paragraphCount` is never less than 1 for non-empty input, even if there isn't a single blank-line-separated break.
 - Built from the other analysis functions internally (`count`, `countWords`, `countSentences`) rather than re-implementing their rules, so anything documented as an edge case for those applies here too.
+
+---
+
+## isPalindrome
+
+Checks whether text reads the same forwards and backwards, ignoring case, spaces, and punctuation.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `boolean` — `true` if text is a palindrome under those rules, `false` otherwise.
+
+**Example:**
+
+```js
+import { isPalindrome } from 'textconvert';
+
+isPalindrome('A man a plan a canal Panama'); // true
+isPalindrome('racecar'); // true
+isPalindrome('hello world'); // false
+```
+
+**Edge Cases:**
+
+- Returns `false` for empty input, matching the boolean-sentinel convention `isEmail`/`isUrl`/`isPhoneNumber` already use.
+- Punctuation/whitespace-only _non-empty_ input (e.g. `'!!!'`) normalizes down to an empty string once case/spaces/punctuation are stripped — treated as `true` (an empty string trivially equals its own reverse), not `false`.
+- Digits are preserved (not stripped as punctuation), so numeric palindromes work too: `isPalindrome('12321')` is `true`.
+- Composes `clear` (lowercases, strips punctuation) and `reverse` internally, so it shares `reverse`'s astral-Unicode limitation — a palindrome check on text containing emoji or other surrogate-pair characters isn't reliable.
 
 ---
 

--- a/src/text/isPalindrome.ts
+++ b/src/text/isPalindrome.ts
@@ -1,0 +1,30 @@
+import { clear } from './clear';
+import { reverse } from './reverse';
+
+/**
+ * Checks whether text reads the same forwards and backwards, ignoring
+ * case, spaces, and punctuation.
+ *
+ * Composes {@link clear} (lowercases, strips punctuation) and
+ * {@link reverse} internally, so it shares reverse's astral-Unicode
+ * limitation on emoji/surrogate-pair characters -- see reverse's own docs.
+ *
+ * @param text Text to check.
+ * @returns `true` if text is a palindrome under those rules, `false` otherwise.
+ * @example
+ * isPalindrome('A man a plan a canal Panama'); // true
+ * isPalindrome('racecar'); // true
+ * isPalindrome('hello world'); // false
+ */
+export function isPalindrome(text: string): boolean {
+  if (!text) return false;
+
+  const normalized = clear(text).replace(/\s+/g, '');
+
+  // Nothing left after stripping case/spaces/punctuation (e.g. text was
+  // punctuation-only, like '!!!') -- an empty string trivially equals its
+  // own reverse.
+  if (!normalized) return true;
+
+  return normalized === reverse(normalized);
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -12,6 +12,7 @@ import { getTextStats, TextStatistics } from './text/analysis/statistics';
 import { clear } from './text/clear';
 import { count, countSentences, countWords } from './text/count';
 import { extractEmails, extractUrls } from './text/extract';
+import { isPalindrome } from './text/isPalindrome';
 import { maskText } from './text/mask';
 import { redact } from './text/redact';
 import { reverse } from './text/reverse';
@@ -35,6 +36,7 @@ export {
   extractUrls,
   getTextStats,
   isEmail,
+  isPalindrome,
   isPhoneNumber,
   isUrl,
   kebabCase,

--- a/tests/Text/isPalindrome.test.ts
+++ b/tests/Text/isPalindrome.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isPalindrome } from '../../src/textConvert';
+
+describe('#isPalindrome', () => {
+  it("should return true for 'racecar'", () => {
+    expect(isPalindrome('racecar')).toBe(true);
+  });
+
+  it("should return true for 'A man a plan a canal Panama', ignoring case and spaces", () => {
+    expect(isPalindrome('A man a plan a canal Panama')).toBe(true);
+  });
+
+  it("should return true for 'Was it a car or a cat I saw?', ignoring punctuation", () => {
+    expect(isPalindrome('Was it a car or a cat I saw?')).toBe(true);
+  });
+
+  it("should return false for 'hello world'", () => {
+    expect(isPalindrome('hello world')).toBe(false);
+  });
+
+  it('should return true for a numeric palindrome', () => {
+    expect(isPalindrome('12321')).toBe(true);
+  });
+
+  it('should return false for a non-palindromic number', () => {
+    expect(isPalindrome('12345')).toBe(false);
+  });
+
+  it('should return true for a single character', () => {
+    expect(isPalindrome('a')).toBe(true);
+  });
+
+  it('should return false for empty input', () => {
+    expect(isPalindrome('')).toBe(false);
+  });
+
+  it('should return true for punctuation-only input, which normalizes to an empty string', () => {
+    expect(isPalindrome('!!!')).toBe(true);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(isPalindrome('RaceCar')).toBe(true);
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#293`

This PR bundles two commits:

### 1. `fix: restore docs/API.md's stub index, reverted by a rebase mistake`

PR #347 turned `docs/API.md` into a ~135-line stub index pointing at the `docs/api/*.md` category files. During #348's merge-conflict resolution, `git checkout --theirs docs/API.md` was used to resolve a rebase conflict — but `--ours`/`--theirs` are inverted during a rebase relative to a normal merge ("ours" is the branch being rebased onto, "theirs" is the commit being replayed), so that command actually kept the stale pre-restructure content instead of adopting `main`'s stub. The file silently reverted to its old ~679-line form and has been broken on `main` since #348 merged, through #349–#352, without anything else referencing its content directly to catch it.

Audited the full diff of that rebase against the correct base it should have used — confirmed only `docs/API.md` was affected; `docs/api/*.md`, `RECIPES.md`'s removal, and the `CONTRIBUTING.md`/`ADDING_FUNCTION.md`/`README.md` updates from #347 were all untouched.

### 2. `feat: add isPalindrome(text) function`

```js
import { isPalindrome } from 'textconvert';

isPalindrome('A man a plan a canal Panama'); // true
isPalindrome('racecar'); // true
isPalindrome('hello world'); // false
```

Composes `clear()` and `reverse()` internally, per #293's own suggested approach, rather than reimplementing reversal/normalization logic.

Edge cases worth calling out:
- Empty input returns `false`, matching the boolean-sentinel convention `isEmail`/`isUrl`/`isPhoneNumber` already use.
- Punctuation/whitespace-only *non-empty* input (e.g. `'!!!'`) normalizes down to an empty string, treated as `true` (vacuously equal to its own reverse) rather than `false`.
- Digits are preserved (`clear()` only strips punctuation), so numeric palindromes like `'12321'` work too.
- Inherits `reverse()`'s astral-Unicode limitation on emoji/surrogate-pair characters, documented alongside it.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

Not a breaking change on either commit.

### References

Closes #293.