### PR TITLE
fix: add explicit return type to reverse, drop --allow-slow-types

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,5 +72,5 @@ jobs:
         # Best-effort mirror alongside npm (the primary registry) -- a JSR
         # hiccup shouldn't fail the whole release workflow after npm has
         # already published successfully.
-        run: npx jsr publish --allow-slow-types
+        run: npx jsr publish
         continue-on-error: true

--- a/src/text/reverse.ts
+++ b/src/text/reverse.ts
@@ -6,8 +6,7 @@
  * reverse('Hello, world!'); // '!dlrow ,olleH'
  */
 
-export function reverse(text: string) {
-  // return type is inferred
+export function reverse(text: string): string {
   // Make sure input is valid
   if (!text) return 'Please provide a valid input text';
   // Split string into characters, reverse all of them and join them back together


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

The package's [JSR score](https://jsr.io/@monsieur-nico/textconvert/score) was sitting at 76%, failing only the "No slow types are used" check. Traced it to `reverse()` being the only exported function in the whole library without an explicit return type — JSR's fast type-check (which statically analyzes source without running the full TS compiler) flags anything relying on inference as a "slow type."

Verified locally via `npx jsr publish --dry-run` (no login needed for a dry run) that this was the *only* slow-types violation in the public API — one function, one missing annotation.

## Changes

- `reverse(text: string)` → `reverse(text: string): string`, and removed a now-inaccurate `// return type is inferred` comment.
- Dropped `--allow-slow-types` from the JSR publish step in `release-please.yml`, now that nothing needs it — a future slow type will fail the publish loudly instead of silently degrading the score again like this one did.

## Impact

- JSR score should go to 100%.
- JSR consumers get a real `.d.ts` file going forward (per JSR's own warning, packages with slow types don't ship one for Node.js users).

### PR checklist

- [ ] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

Not a breaking change — the function's runtime behavior and TS-inferred type were already `string`; this just makes it explicit for JSR's benefit.

### References

None — found while looking into why the JSR score wasn't 100%.