### PR TITLE
feat: add extractMentions and extractHashtags functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - **CLI:** `npx textconvert redact <file>` sanitizes a file (or stdin) from the command line, no JS required
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify, capitalize, Title Case
 - Validation: email addresses, URLs, and phone numbers
-- Extraction: pull email addresses and URLs out of a block of text
+- Extraction: pull email addresses, URLs, @mentions, and #hashtags out of a block of text
 - Text analysis: word/letter/sentence/paragraph counting, reading time, palindrome checking, etc.
 - Text utilities: truncate with word-boundary awareness
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
@@ -145,6 +145,8 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `isPhoneNumber(text)`                        | Validate a phone number                               |
 | `extractEmails(text)`                        | Extract all email addresses found in a block of text  |
 | `extractUrls(text)`                          | Extract all URLs found in a block of text             |
+| `extractMentions(text)`                      | Extract all @mentions found in a block of text        |
+| `extractHashtags(text)`                      | Extract all #hashtags found in a block of text        |
 
 See [docs/API.md](docs/API.md) for full parameter, return type, and edge-case details on every function, or browse the auto-generated [API reference site](https://monsieur-nico.github.io/textConvert/).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@ Detailed documentation for every function has moved into per-category files unde
 
 - [**Case Conversion**](api/case-conversion.md) — [camelCase](#camelcase), [pascalCase](#pascalcase), [snakeCase](#snakecase), [kebabCase](#kebabcase), [slugify](#slugify), [capitalize](#capitalize), [titleCase](#titlecase)
 - [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
-- [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls)
+- [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls), [extractMentions](#extractmentions), [extractHashtags](#extracthashtags)
 - [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
@@ -69,6 +69,14 @@ Full docs: [docs/api/extraction.md#extractemails](api/extraction.md#extractemail
 ### extractUrls
 
 Full docs: [docs/api/extraction.md#extracturls](api/extraction.md#extracturls)
+
+### extractMentions
+
+Full docs: [docs/api/extraction.md#extractmentions](api/extraction.md#extractmentions)
+
+### extractHashtags
+
+Full docs: [docs/api/extraction.md#extracthashtags](api/extraction.md#extracthashtags)
 
 ---
 

--- a/docs/api/extraction.md
+++ b/docs/api/extraction.md
@@ -1,8 +1,8 @@
 # Extraction
 
-`extractEmails`, `extractUrls`.
+`extractEmails`, `extractUrls`, `extractMentions`, `extractHashtags`.
 
-Both functions find candidate substrings in free-form text with a single linear pass (no regex backtracking risk — see each function's ReDoS note below), then validate every candidate with `isEmail`/`isUrl` before including it, so results are exactly the substrings that would independently pass validation. See [validation.md](validation.md) for the exact rules those two apply.
+All four functions find candidate substrings in free-form text with a single linear pass (no regex backtracking risk — see each function's notes below). `extractEmails`/`extractUrls` validate every candidate with `isEmail`/`isUrl` before including it, so results are exactly the substrings that would independently pass validation — see [validation.md](validation.md) for the exact rules those two apply. `extractMentions`/`extractHashtags` don't have a separate validator to check against; their character-class scan already guarantees a correctly-shaped result on its own.
 
 ---
 
@@ -10,6 +10,8 @@ Both functions find candidate substrings in free-form text with a single linear 
 
 - [extractEmails](#extractemails)
 - [extractUrls](#extracturls)
+- [extractMentions](#extractmentions)
+- [extractHashtags](#extracthashtags)
 
 ---
 
@@ -74,3 +76,67 @@ extractUrls('Check out https://example.com and http://another.example.org/path f
 - Only `http://`/`https://` are recognized as URL starts, matching `isUrl`'s scope — a bare `example.com` or an `ftp://` link in the text is never extracted.
 - Excludes common wrapping delimiters (quotes, angle brackets, parentheses) from the match, and strips trailing sentence punctuation before validating — `"See https://example.com."` extracts `https://example.com`, not `https://example.com.`.
 - Since every candidate is independently validated with `isUrl`, the same IPv4-hostname exception documented there applies here too.
+
+---
+
+## extractMentions
+
+Extracts all `@mentions` found in a block of text, symbol included.
+
+**Parameters:**
+
+- `text: string` — The text to search for mentions.
+
+**Returns:**
+
+- `string[]` — The mentions found (including the leading `@`), in the order they appear.
+
+**Example:**
+
+```js
+import { extractMentions } from 'textconvert';
+
+extractMentions('Thanks @jordan and @alex_dev for the review!');
+// ['@jordan', '@alex_dev']
+```
+
+**How matching works:** each `@` is checked against the character immediately before it — a match only starts when that character isn't itself a letter/digit/underscore. The body after `@` is a run of letters, digits, and underscores (the common convention across Twitter/X, Instagram, and similar platforms) — no hyphens, no dots.
+
+**Edge Cases:**
+
+- Returns an empty array for empty input or when no mentions are found.
+- The not-preceded-by-a-body-character rule means an email address's `@` is never mistaken for a mention: `extractMentions('user@example.com')` returns `[]`, not `['@example']`.
+- No separate trailing-punctuation stripping is needed (unlike `extractEmails`/`extractUrls`) — since the body is letters/digits/underscore only, the character scan itself naturally stops before any trailing punctuation, e.g. `extractMentions('Thanks, @jordan!')` → `['@jordan']`.
+- Does not de-duplicate — the same mention appearing twice in the input appears twice in the result, in order.
+
+---
+
+## extractHashtags
+
+Extracts all `#hashtags` found in a block of text, symbol included.
+
+**Parameters:**
+
+- `text: string` — The text to search for hashtags.
+
+**Returns:**
+
+- `string[]` — The hashtags found (including the leading `#`), in the order they appear.
+
+**Example:**
+
+```js
+import { extractHashtags } from 'textconvert';
+
+extractHashtags('Just shipped v2! #typescript #opensource #buildinpublic');
+// ['#typescript', '#opensource', '#buildinpublic']
+```
+
+**How matching works:** identical rule to `extractMentions` above (see there for the full explanation), just anchored on `#` instead of `@`.
+
+**Edge Cases:**
+
+- Returns an empty array for empty input or when no hashtags are found.
+- The same not-preceded-by-a-body-character rule that keeps `extractMentions` from matching inside an email has a useful side effect here too: it keeps a language name like `C#` from being mistaken for a hashtag — `extractHashtags('Written in C#')` returns `[]`.
+- No separate trailing-punctuation stripping needed, same reasoning as `extractMentions`.
+- Does not de-duplicate.

--- a/src/text/extract.ts
+++ b/src/text/extract.ts
@@ -1,4 +1,4 @@
-import { stripTrailing } from './internal/scan';
+import { findPrefixedTokens, stripTrailing } from './internal/scan';
 import { isEmail } from './validation/email';
 import { isUrl } from './validation/url';
 
@@ -111,4 +111,49 @@ export function extractUrls(text: string): string[] {
   if (!text) return [];
 
   return findUrlCandidates(text).map(stripTrailingPunctuation).filter(isUrl);
+}
+
+// Characters allowed in a mention/hashtag body: letters, digits, and
+// underscore -- the common convention across Twitter/X, Instagram, and
+// similar platforms.
+const mentionHashtagBodyChars = new Set(
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_',
+);
+
+/**
+ * Extracts all @mentions found in a block of text, symbol included.
+ *
+ * A match only starts when the `@` isn't immediately preceded by a
+ * letter/digit/underscore, so an email address's `@` (e.g.
+ * `user@example.com`) is never mistaken for a mention.
+ *
+ * @param text Text to search for mentions.
+ * @returns An array of the mentions found (including the leading `@`), in the order they appear.
+ * @example
+ * extractMentions('Thanks @jordan and @alex_dev for the review!');
+ * // ['@jordan', '@alex_dev']
+ */
+export function extractMentions(text: string): string[] {
+  if (!text) return [];
+
+  return findPrefixedTokens(text, '@', mentionHashtagBodyChars);
+}
+
+/**
+ * Extracts all #hashtags found in a block of text, symbol included.
+ *
+ * Uses the same not-preceded-by-a-body-character rule as {@link
+ * extractMentions}, which has a useful side effect: it also keeps a
+ * language name like `C#` from being mistaken for a hashtag.
+ *
+ * @param text Text to search for hashtags.
+ * @returns An array of the hashtags found (including the leading `#`), in the order they appear.
+ * @example
+ * extractHashtags('Just shipped v2! #typescript #opensource #buildinpublic');
+ * // ['#typescript', '#opensource', '#buildinpublic']
+ */
+export function extractHashtags(text: string): string[] {
+  if (!text) return [];
+
+  return findPrefixedTokens(text, '#', mentionHashtagBodyChars);
 }

--- a/src/text/internal/scan.ts
+++ b/src/text/internal/scan.ts
@@ -40,3 +40,29 @@ export function stripTrailing(value: string, chars: Set<string>): string {
   while (end > 0 && chars.has(value[end - 1])) end--;
   return value.slice(0, end);
 }
+
+/**
+ * Finds `prefix`-anchored tokens (e.g. `@mentions`, `#hashtags`): a single
+ * `prefix` character followed by a run of one or more `bodyChars`. A match
+ * only starts when the prefix isn't immediately preceded by a body
+ * character itself, so e.g. `findPrefixedTokens('user@example.com', '@',
+ * wordChars)` doesn't treat the email's `@` as a token start. A single
+ * linear pass, no regex backtracking risk.
+ */
+export function findPrefixedTokens(text: string, prefix: string, bodyChars: Set<string>): string[] {
+  const candidates: string[] = [];
+
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== prefix) continue;
+    if (i > 0 && bodyChars.has(text[i - 1])) continue;
+
+    let end = i + 1;
+    while (end < text.length && bodyChars.has(text[end])) end++;
+
+    if (end > i + 1) candidates.push(text.slice(i, end));
+
+    i = end - 1;
+  }
+
+  return candidates;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -11,7 +11,7 @@ import { detectLanguage, Language, LanguageDetectionResult } from './text/analys
 import { getTextStats, TextStatistics } from './text/analysis/statistics';
 import { clear } from './text/clear';
 import { count, countSentences, countWords } from './text/count';
-import { extractEmails, extractUrls } from './text/extract';
+import { extractEmails, extractHashtags, extractMentions, extractUrls } from './text/extract';
 import { isPalindrome } from './text/isPalindrome';
 import { maskText } from './text/mask';
 import { redact } from './text/redact';
@@ -33,6 +33,8 @@ export {
   countWords,
   detectLanguage,
   extractEmails,
+  extractHashtags,
+  extractMentions,
   extractUrls,
   getTextStats,
   isEmail,

--- a/tests/Text/extract.test.ts
+++ b/tests/Text/extract.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { extractEmails, extractUrls } from '../../src/textConvert';
+import {
+  extractEmails,
+  extractHashtags,
+  extractMentions,
+  extractUrls,
+} from '../../src/textConvert';
 
 describe('#extractEmails', () => {
   it('should extract multiple emails from a sentence', () => {
@@ -63,5 +68,72 @@ describe('#extractUrls', () => {
 
   it('should return an empty array for empty input', () => {
     expect(extractUrls('')).toEqual([]);
+  });
+});
+
+describe('#extractMentions', () => {
+  it('should extract multiple mentions from a sentence', () => {
+    expect(extractMentions('Thanks @jordan and @alex_dev for the review!')).toEqual([
+      '@jordan',
+      '@alex_dev',
+    ]);
+  });
+
+  it('should keep the leading @ symbol', () => {
+    expect(extractMentions('cc @octocat')).toEqual(['@octocat']);
+  });
+
+  it('should not match an email address as a mention', () => {
+    expect(extractMentions('Contact user@example.com for help')).toEqual([]);
+  });
+
+  it('should extract a real mention even when an email is present too', () => {
+    expect(extractMentions('email me at hello@example.com or ping @jordan')).toEqual(['@jordan']);
+  });
+
+  it('should include digits and underscores in the mention body', () => {
+    expect(extractMentions('shoutout to @user_123')).toEqual(['@user_123']);
+  });
+
+  it('should stop a mention at punctuation, without needing separate stripping', () => {
+    expect(extractMentions('Thanks, @jordan!')).toEqual(['@jordan']);
+  });
+
+  it('should return an empty array when there are no mentions', () => {
+    expect(extractMentions('No mentions here.')).toEqual([]);
+  });
+
+  it('should return an empty array for empty input', () => {
+    expect(extractMentions('')).toEqual([]);
+  });
+});
+
+describe('#extractHashtags', () => {
+  it('should extract multiple hashtags from a sentence', () => {
+    expect(extractHashtags('Just shipped v2! #typescript #opensource #buildinpublic')).toEqual([
+      '#typescript',
+      '#opensource',
+      '#buildinpublic',
+    ]);
+  });
+
+  it('should keep the leading # symbol', () => {
+    expect(extractHashtags('so much #hype')).toEqual(['#hype']);
+  });
+
+  it('should not match "C#" as a hashtag', () => {
+    expect(extractHashtags('Written in C#')).toEqual([]);
+  });
+
+  it('should include digits and underscores in the hashtag body', () => {
+    expect(extractHashtags('#web3 #the_best')).toEqual(['#web3', '#the_best']);
+  });
+
+  it('should return an empty array when there are no hashtags', () => {
+    expect(extractHashtags('No hashtags here.')).toEqual([]);
+  });
+
+  it('should return an empty array for empty input', () => {
+    expect(extractHashtags('')).toEqual([]);
   });
 });


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#325`

```js
import { extractMentions, extractHashtags } from 'textconvert';

extractMentions('Thanks @jordan and @alex_dev for the review!');
// ['@jordan', '@alex_dev']

extractHashtags('Just shipped v2! #typescript #opensource #buildinpublic');
// ['#typescript', '#opensource', '#buildinpublic']
```

Same "find embedded matches in free text" pattern already established by `extractEmails`/`extractUrls`, extended to social-content parsing.

### Scope decisions (per #325's open questions)

- Keep the `@`/`#` symbol in results, matching `extractEmails` returning the full address rather than just the local part.
- Match body is letters/digits/underscore only (the common convention across Twitter/X, Instagram, and similar platforms) — no hyphens, no dots.
- A match only starts when the `@`/`#` isn't immediately preceded by a body character, so an email's `@` is never mistaken for a mention: `extractMentions('user@example.com')` → `[]`. Useful side effect: it also keeps `C#` from being mistaken for a hashtag.
- No trailing-punctuation stripping needed, unlike `extractEmails`/`extractUrls` — the word-char-only body means the scan itself already stops in the right place (`extractMentions('Thanks, @jordan!')` → `['@jordan']`).
- No de-duplication, matching the existing `extractEmails`/`extractUrls` convention.

### Implementation

Both functions share nearly identical scan logic (prefix character + body-char run + boundary check), so that logic is a new shared `findPrefixedTokens` helper in `src/text/internal/scan.ts` rather than duplicated twice — continuing the DRY pattern from the earlier `extract.ts`/`redact.ts` refactor (#342).

Verified via `npx jsr publish --dry-run` that the new exports (both have explicit return types) don't reintroduce the slow-types issue just fixed in #356.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

Not a breaking change.

### References

Closes #325.