### PR TITLE
feat: add escapeHtml and unescapeHtml functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 ## ✨ Features
 
 - **PII redaction:** mask emails, phone numbers, credit card numbers, and (opt-in) API keys/tokens embedded in free-form text, or partially mask a known value for display
+- **XSS-safe HTML escaping:** escape/unescape the five HTML special characters per OWASP's XSS Prevention Cheat Sheet, without a dedicated escaping library
 - **CLI:** `npx textconvert redact <file>` sanitizes a file (or stdin) from the command line, no JS required
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify, capitalize, Title Case
 - Validation: email addresses, URLs, and phone numbers
@@ -147,6 +148,8 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `extractUrls(text)`                          | Extract all URLs found in a block of text             |
 | `extractMentions(text)`                      | Extract all @mentions found in a block of text        |
 | `extractHashtags(text)`                      | Extract all #hashtags found in a block of text        |
+| `escapeHtml(text)`                           | Escape the five HTML special characters               |
+| `unescapeHtml(text)`                         | Reverse `escapeHtml`'s escaping                       |
 
 See [docs/API.md](docs/API.md) for full parameter, return type, and edge-case details on every function, or browse the auto-generated [API reference site](https://monsieur-nico.github.io/textConvert/).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Case Conversion**](api/case-conversion.md) — [camelCase](#camelcase), [pascalCase](#pascalcase), [snakeCase](#snakecase), [kebabCase](#kebabcase), [slugify](#slugify), [capitalize](#capitalize), [titleCase](#titlecase)
 - [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
 - [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls), [extractMentions](#extractmentions), [extractHashtags](#extracthashtags)
-- [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext)
+- [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
@@ -89,6 +89,14 @@ Full docs: [docs/api/security.md#redact](api/security.md#redact)
 ### maskText
 
 Full docs: [docs/api/security.md#masktext](api/security.md#masktext)
+
+### escapeHtml
+
+Full docs: [docs/api/security.md#escapehtml](api/security.md#escapehtml)
+
+### unescapeHtml
+
+Full docs: [docs/api/security.md#unescapehtml](api/security.md#unescapehtml)
 
 ---
 

--- a/docs/api/security.md
+++ b/docs/api/security.md
@@ -1,6 +1,6 @@
 # Security
 
-`redact`, `maskText`.
+`redact`, `maskText`, `escapeHtml`, `unescapeHtml`.
 
 ---
 
@@ -8,6 +8,8 @@
 
 - [redact](#redact)
 - [maskText](#masktext)
+- [escapeHtml](#escapehtml)
+- [unescapeHtml](#unescapehtml)
 
 ---
 
@@ -92,3 +94,64 @@ function maskEmail(email) {
 - If the requested visible portions (start + end) cover the whole string, returns the string unchanged rather than over-masking.
 - `visibleStart`/`visibleEnd` are clamped to the string's length, and clamped further so the two visible portions never overlap.
 - `maskChar` isn't restricted to a single character — passing a multi-character string (e.g. `'#*'`) repeats the whole string per masked position, so the masked region's length can differ from the number of masked characters. Pass a single character if you need a 1:1 length match.
+
+---
+
+## escapeHtml
+
+Escapes the five HTML special characters (`& < > " '`) in a string, per [OWASP's XSS Prevention Cheat Sheet Rule #1](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) for HTML element content — useful for safely rendering user-supplied text without pulling in a dedicated escaping library.
+
+This covers HTML element content only, not other injection contexts (HTML attributes, `<script>` bodies, CSS, URLs) — those need different, context-specific encoding that this function doesn't provide.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The escaped string, or an error message for invalid input.
+
+**Example:**
+
+```js
+import { escapeHtml } from 'textconvert';
+
+escapeHtml('<script>alert("hi")</script>');
+// '&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt;'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- The five escaped characters are `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`, `'` → `&#x27;` — the hex numeric form for apostrophe, matching OWASP's own convention (some other escaping libraries, e.g. lodash, use the decimal `&#39;` instead — both decode identically in every HTML parser, this just documents which one `escapeHtml` itself produces).
+- Backtick is deliberately **not** escaped — it's not part of OWASP's Rule #1 for HTML element content, despite sometimes being confused for one (it shows up in separate, unrelated advice about never using backtick as an HTML attribute delimiter).
+- Implemented as a single pass over the string with one combined regex, not chained sequential replacements — chaining would corrupt its own output (escaping `<` before `&` would turn the resulting `&lt;` into `&amp;lt;` on a second pass).
+
+---
+
+## unescapeHtml
+
+Reverses exactly the five escapes `escapeHtml` produces.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The unescaped string, or an error message for invalid input.
+
+**Example:**
+
+```js
+import { unescapeHtml } from 'textconvert';
+
+unescapeHtml('Tom &amp; Jerry');
+// 'Tom & Jerry'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- **Not a general-purpose HTML entity decoder.** Only the five entities `escapeHtml` produces are reversed — `&nbsp;`, `&copy;`, numeric character references like `&#65;`, and every other named or numeric entity are left untouched, by design.
+- Accepts both `&#x27;` (hex, what `escapeHtml` produces) and `&#39;` (decimal) as valid apostrophe input, plus the named `&apos;` form — even though `escapeHtml` only ever outputs `&#x27;`, so round-tripping output from other tools that use a different convention still works.

--- a/src/text/html.ts
+++ b/src/text/html.ts
@@ -1,0 +1,76 @@
+// The five characters OWASP's Cross-Site Scripting Prevention Cheat Sheet
+// (Rule #1, HTML element content) requires escaping -- the deliberate,
+// documented scope for v1, not a general-purpose HTML sanitizer. Apostrophe
+// uses the hex numeric reference (&#x27;) to match OWASP's own convention.
+const htmlEscapes: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+};
+
+// Reverses exactly the escapes above. Also accepts &#39; (the decimal
+// numeric form other tools commonly produce for apostrophe) and &apos;
+// (the HTML5 named form) as equivalent input, even though escapeHtml never
+// outputs either -- this is not a general HTML entity decoder, it only
+// reverses these five characters' escaped forms.
+const htmlUnescapes: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#x27;': "'",
+  '&#39;': "'",
+  '&apos;': "'",
+};
+
+// Single-pass regexes matched against a lookup-map replacer, rather than
+// chained sequential .replace() calls -- chaining would corrupt already-
+// escaped output (e.g. escaping '<' before '&' would turn the resulting
+// '&lt;' into '&amp;lt;' on the next pass). Matching all target characters
+// in one pass sidesteps that entirely: nothing a replacer inserts is
+// re-scanned by the same pass.
+const escapeRegex = /[&<>"']/g;
+const unescapeRegex = /&amp;|&lt;|&gt;|&quot;|&#x27;|&#39;|&apos;/g;
+
+/**
+ * Escapes the five HTML special characters (`& < > " '`) in a string, per
+ * OWASP's XSS Prevention Cheat Sheet Rule #1 for HTML element content --
+ * useful for safely rendering user-supplied text without pulling in a
+ * dedicated escaping library.
+ *
+ * This covers HTML element content only, not other injection contexts
+ * (HTML attributes, `<script>` bodies, CSS, URLs) -- those need different,
+ * context-specific encoding that this function doesn't provide. See
+ * {@link unescapeHtml} for the reverse operation.
+ *
+ * @param text Text to escape.
+ * @returns The escaped string, or an error message for invalid input.
+ * @example
+ * escapeHtml('<script>alert("hi")</script>');
+ * // '&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt;'
+ */
+export function escapeHtml(text: string): string {
+  if (!text) return 'Please provide a valid input text';
+
+  return text.replace(escapeRegex, (char) => htmlEscapes[char]);
+}
+
+/**
+ * Reverses exactly the five escapes {@link escapeHtml} produces. This is
+ * not a general-purpose HTML entity decoder -- entities it doesn't produce
+ * (`&nbsp;`, `&copy;`, numeric character references like `&#65;`, etc.)
+ * are left untouched, by design.
+ *
+ * @param text Text to unescape.
+ * @returns The unescaped string, or an error message for invalid input.
+ * @example
+ * unescapeHtml('Tom &amp; Jerry');
+ * // 'Tom & Jerry'
+ */
+export function unescapeHtml(text: string): string {
+  if (!text) return 'Please provide a valid input text';
+
+  return text.replace(unescapeRegex, (entity) => htmlUnescapes[entity]);
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -12,6 +12,7 @@ import { getTextStats, TextStatistics } from './text/analysis/statistics';
 import { clear } from './text/clear';
 import { count, countSentences, countWords } from './text/count';
 import { extractEmails, extractHashtags, extractMentions, extractUrls } from './text/extract';
+import { escapeHtml, unescapeHtml } from './text/html';
 import { isPalindrome } from './text/isPalindrome';
 import { maskText } from './text/mask';
 import { redact } from './text/redact';
@@ -32,6 +33,7 @@ export {
   countSentences,
   countWords,
   detectLanguage,
+  escapeHtml,
   extractEmails,
   extractHashtags,
   extractMentions,
@@ -55,4 +57,5 @@ export {
   TextStatistics,
   titleCase,
   truncate,
+  unescapeHtml,
 };

--- a/tests/Text/html.test.ts
+++ b/tests/Text/html.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml, unescapeHtml } from '../../src/textConvert';
+
+describe('#escapeHtml', () => {
+  it('should escape all five special characters', () => {
+    expect(escapeHtml('<script>alert("hi")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt;',
+    );
+  });
+
+  it('should escape an ampersand', () => {
+    expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+  });
+
+  it('should escape a single quote as the hex numeric reference &#x27;', () => {
+    expect(escapeHtml("It's a test")).toBe('It&#x27;s a test');
+  });
+
+  it('should not double-escape an ampersand introduced by another escape', () => {
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('<')).not.toBe('&amp;lt;');
+  });
+
+  it('should leave text with no special characters unchanged', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+
+  it('should return an error message for empty input', () => {
+    expect(escapeHtml('')).toBe('Please provide a valid input text');
+  });
+});
+
+describe('#unescapeHtml', () => {
+  it('should unescape all five special characters', () => {
+    expect(unescapeHtml('&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt;')).toBe(
+      '<script>alert("hi")</script>',
+    );
+  });
+
+  it('should unescape an ampersand entity', () => {
+    expect(unescapeHtml('Tom &amp; Jerry')).toBe('Tom & Jerry');
+  });
+
+  it('should unescape both the hex and decimal apostrophe forms', () => {
+    expect(unescapeHtml('It&#x27;s a test')).toBe("It's a test");
+    expect(unescapeHtml('It&#39;s a test')).toBe("It's a test");
+  });
+
+  it('should unescape the named &apos; form even though escapeHtml never produces it', () => {
+    expect(unescapeHtml('It&apos;s a test')).toBe("It's a test");
+  });
+
+  it('should round-trip with escapeHtml', () => {
+    const original = '<div class="a">Tom & Jerry\'s "great" show</div>';
+    expect(unescapeHtml(escapeHtml(original))).toBe(original);
+  });
+
+  it('should leave entities it does not recognize untouched (not a general HTML entity decoder)', () => {
+    expect(unescapeHtml('Caf&eacute; &nbsp; &#65;')).toBe('Caf&eacute; &nbsp; &#65;');
+  });
+
+  it('should leave text with no entities unchanged', () => {
+    expect(unescapeHtml('hello world')).toBe('hello world');
+  });
+
+  it('should return an error message for empty input', () => {
+    expect(unescapeHtml('')).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

`#326`

```js
import { escapeHtml, unescapeHtml } from 'textconvert';

escapeHtml('<script>alert("hi")</script>');
// '&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt;'

unescapeHtml('Tom &amp; Jerry');
// 'Tom & Jerry'
```

### Scope decisions (per #326's open question)

Rather than assume from memory, verified directly against [OWASP's Cross-Site Scripting Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html), Rule #1 (HTML element content):

- Exactly the five characters OWASP's Rule #1 lists — `& < > " '`. Confirmed backtick is **not** part of that rule (I'd initially thought it might be, but that was conflating it with unrelated advice elsewhere about never using backtick as an HTML attribute delimiter).
- Apostrophe escapes to the hex numeric form `&#x27;`, matching OWASP's own convention — not the decimal `&#39;` some other escaping libraries (e.g. lodash) use. Both decode identically in every HTML parser; this is purely about which literal form `escapeHtml` itself produces.
- `unescapeHtml` still accepts `&#39;` and the named `&apos;` form as valid input, even though `escapeHtml` never produces either — so round-tripping with other tools' output still works.
- `unescapeHtml` is explicitly scoped to reversing only these five escapes, **not** a general-purpose HTML entity decoder — `&nbsp;`, `&copy;`, numeric character references, etc. are deliberately left untouched.

### Implementation

Single-pass regex + lookup-map replacer for both directions, not chained sequential `.replace()` calls — chaining would corrupt already-escaped output (escaping `<` before `&` would turn the resulting `&lt;` into `&amp;lt;` on a second pass).

Docs added to `docs/api/security.md` (alongside `redact`/`maskText`, matching the `security` label on #326), plus `docs/API.md`'s stub index and README.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

Not a breaking change.

### References

Closes #326.