### PR TITLE
feat: add wordFrequency(text) function

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify, capitalize, Title Case
 - Validation: email addresses, URLs, and phone numbers
 - Extraction: pull email addresses, URLs, @mentions, and #hashtags out of a block of text
-- Text analysis: word/letter/sentence/paragraph counting, reading time, palindrome checking, etc.
+- Text analysis: word/letter/sentence/paragraph counting, reading time, palindrome checking, word frequency, etc.
 - Text utilities: truncate with word-boundary awareness
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
@@ -139,6 +139,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `redact(text, options?)`                     | Mask PII/secrets embedded in text                     |
 | `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time) |
 | `isPalindrome(text)`                         | Check if text is a palindrome                         |
+| `wordFrequency(text)`                        | Count how many times each word appears                |
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |
 | `isEmail(text)`                              | Validate an email address                             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
 - [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls), [extractMentions](#extractmentions), [extractHashtags](#extracthashtags)
 - [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml)
-- [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
+- [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate), [wordFrequency](#wordfrequency)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
 
@@ -137,6 +137,10 @@ Full docs: [docs/api/text-analysis.md#spread](api/text-analysis.md#spread)
 ### truncate
 
 Full docs: [docs/api/text-analysis.md#truncate](api/text-analysis.md#truncate)
+
+### wordFrequency
+
+Full docs: [docs/api/text-analysis.md#wordfrequency](api/text-analysis.md#wordfrequency)
 
 ---
 

--- a/docs/api/text-analysis.md
+++ b/docs/api/text-analysis.md
@@ -1,6 +1,6 @@
 # Text Analysis
 
-`clear`, `count`, `countWords`, `countSentences`, `getTextStats`, `isPalindrome`, `reverse`, `spread`, `truncate`.
+`clear`, `count`, `countWords`, `countSentences`, `getTextStats`, `isPalindrome`, `reverse`, `spread`, `truncate`, `wordFrequency`.
 
 ---
 
@@ -15,6 +15,7 @@
 - [reverse](#reverse)
 - [spread](#spread)
 - [truncate](#truncate)
+- [wordFrequency](#wordfrequency)
 
 ---
 
@@ -307,3 +308,31 @@ truncate('Short text', 20); // 'Short text'
 - Returns an error message for empty input.
 - If `maxLength` is smaller than or equal to the ellipsis length, returns as much of the ellipsis as fits (not the ellipsis in full, and not any of the original text).
 - With `byWords`, falls back to a hard mid-word cut if there's no word boundary before the cut point (e.g. one very long word longer than `maxLength`).
+
+---
+
+## wordFrequency
+
+Counts how many times each word appears in a piece of text. Case-insensitive by default — reuses `clear`'s existing lowercasing/punctuation-stripping split rather than a separate tokenizer, so "The" and "the" count together, and a trailing apostrophe (`don't`) splits into two words the same way `clear`/`count` already treat it.
+
+**Parameters:**
+
+- `text: string` — The input string to count word frequency in.
+
+**Returns:**
+
+- `Record<string, number>` — A map of each distinct word to how many times it appears, in first-appearance order.
+
+**Example:**
+
+```js
+import { wordFrequency } from 'textconvert';
+
+wordFrequency('the cat sat on the mat');
+// { the: 2, cat: 1, sat: 1, on: 1, mat: 1 }
+```
+
+**Edge Cases:**
+
+- Returns an empty object (`{}`) for empty, whitespace-only, or punctuation-only input — not the shared `'Please provide a valid input text'` error string, since an empty frequency map is itself a valid, useful answer here.
+- Contractions split on the apostrophe (`don't` → `don` and `t` counted separately), matching `clear`'s existing punctuation-stripping behavior rather than introducing special-case handling.

--- a/src/text/analysis/wordFrequency.ts
+++ b/src/text/analysis/wordFrequency.ts
@@ -1,0 +1,27 @@
+import { clear } from '../clear';
+
+/**
+ * Counts how many times each word appears in a piece of text. Case-insensitive
+ * by default -- "The" and "the" count as the same word, since this reuses
+ * `clear()`'s existing lowercasing/punctuation-stripping split rather than a
+ * separate tokenizer.
+ *
+ * @param text Text to count word frequency in.
+ * @returns A map of each distinct word to how many times it appears, in the
+ * order each word first appeared.
+ * @example
+ * wordFrequency('the cat sat on the mat');
+ * // { the: 2, cat: 1, sat: 1, on: 1, mat: 1 }
+ */
+export function wordFrequency(text: string): Record<string, number> {
+  if (!text?.trim()) return {};
+
+  const frequency: Record<string, number> = {};
+
+  for (const word of clear(text).split(' ')) {
+    if (!word) continue;
+    frequency[word] = (frequency[word] ?? 0) + 1;
+  }
+
+  return frequency;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -9,6 +9,7 @@ import {
 
 import { detectLanguage, Language, LanguageDetectionResult } from './text/analysis/language';
 import { getTextStats, TextStatistics } from './text/analysis/statistics';
+import { wordFrequency } from './text/analysis/wordFrequency';
 import { clear } from './text/clear';
 import { count, countSentences, countWords } from './text/count';
 import { extractEmails, extractHashtags, extractMentions, extractUrls } from './text/extract';
@@ -58,4 +59,5 @@ export {
   titleCase,
   truncate,
   unescapeHtml,
+  wordFrequency,
 };

--- a/tests/Text/Analysis/wordFrequency.test.ts
+++ b/tests/Text/Analysis/wordFrequency.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { wordFrequency } from '../../../src/text/analysis/wordFrequency';
+
+describe('#wordFrequency', () => {
+  it('counts repeated words', () => {
+    expect(wordFrequency('the cat sat on the mat')).toEqual({
+      the: 2,
+      cat: 1,
+      sat: 1,
+      on: 1,
+      mat: 1,
+    });
+  });
+
+  it('is case-insensitive', () => {
+    expect(wordFrequency('The cat and the CAT')).toEqual({
+      the: 2,
+      cat: 2,
+      and: 1,
+    });
+  });
+
+  it('strips punctuation before counting', () => {
+    expect(wordFrequency('Hello, world! Hello?')).toEqual({
+      hello: 2,
+      world: 1,
+    });
+  });
+
+  it('returns an empty object for empty input', () => {
+    expect(wordFrequency('')).toEqual({});
+  });
+
+  it('returns an empty object for whitespace-only input', () => {
+    expect(wordFrequency('   ')).toEqual({});
+  });
+
+  it('returns an empty object for punctuation-only input', () => {
+    expect(wordFrequency('...!?')).toEqual({});
+  });
+
+  it('preserves first-appearance order of keys', () => {
+    expect(Object.keys(wordFrequency('banana apple banana cherry apple'))).toEqual([
+      'banana',
+      'apple',
+      'cherry',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #292.

Adds `wordFrequency(text)`, returning how many times each word appears in a piece of text. Case-insensitive by default, per the issue's own recommendation — reuses `clear()`'s existing lowercasing/punctuation-stripping split rather than a separate tokenizer, so it stays consistent with `count()`/`countWords()`'s established word-splitting behavior instead of introducing a second one.

```ts
wordFrequency('the cat sat on the mat');
// { the: 2, cat: 1, sat: 1, on: 1, mat: 1 }
```

Lives in `src/text/analysis/` alongside `getTextStats`/`detectLanguage`, matching the issue's suggested placement.