### PR TITLE
ci: add textconvert-refcheck

### DIFF
--- a/.github/workflows/refcheck.yml
+++ b/.github/workflows/refcheck.yml
@@ -1,0 +1,20 @@
+name: Reference Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  refcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Monsieur-Nico/textconvert-refcheck@v1
+        with:
+          fail-on-violation: false


### PR DESCRIPTION
Adds [textconvert-refcheck](https://github.com/Monsieur-Nico/textconvert-refcheck) to this repo, catching typo'd @mentions and dangling issue/PR/file references in PR and issue bodies -- the sibling Action built alongside this library.

Uses the exact usage documented in its own README: runs on PR open/edit/synchronize and issue open/edit, posts a single summary comment (updated in place, not a new comment per run), `fail-on-violation: false` so it's informational only and never blocks a merge.