### PR TITLE
feat: add randomString(length, options?) function

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Text utilities: truncate with word-boundary awareness
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
+- Generation: cryptographically secure random strings for IDs, tokens, or test fixtures
 - Pure, dependency-free, and TypeScript-ready
 
 ---
@@ -141,6 +142,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `isPalindrome(text)`                         | Check if text is a palindrome                         |
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |
+| `randomString(length, options?)`             | Generate a cryptographically secure random string     |
 | `isEmail(text)`                              | Validate an email address                             |
 | `isUrl(text)`                                | Validate a URL                                        |
 | `isPhoneNumber(text)`                        | Validate a phone number                               |

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,6 +9,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
+- [**Generation**](api/generation.md) — [randomString](#randomstring)
 
 ---
 
@@ -153,3 +154,11 @@ Full docs: [docs/api/language.md#detectlanguage](api/language.md#detectlanguage)
 ### numbersToWords
 
 Full docs: [docs/api/numbers.md#numberstowords](api/numbers.md#numberstowords)
+
+---
+
+## Generation
+
+### randomString
+
+Full docs: [docs/api/generation.md#randomstring](api/generation.md#randomstring)

--- a/docs/api/generation.md
+++ b/docs/api/generation.md
@@ -1,0 +1,34 @@
+# Generation
+
+`randomString`.
+
+---
+
+## randomString
+
+Generates a random string of a given length, drawn from a cryptographically secure source (`globalThis.crypto.getRandomValues`, the standard Web Crypto API available in both Node and browsers — nothing here falls back to `Math.random`). Suitable for one-off IDs, tokens, or test fixtures.
+
+**Parameters:**
+
+- `length: number` — Number of characters to generate.
+- `options?: { charset?: 'alpha' | 'numeric' | 'alphanumeric' | string }` — `'alpha'` (letters only), `'numeric'` (digits only), `'alphanumeric'` (the default), or any other string, used literally as the pool of characters to draw from (e.g. `'ABC123'`).
+
+**Returns:**
+
+- `string` — A random string of the requested length, or `''` if `length` or the resolved charset is empty.
+
+**Example:**
+
+```js
+import { randomString } from 'textconvert';
+
+randomString(8); // e.g. 'aZ3kD9pQ' (alphanumeric by default)
+randomString(6, { charset: 'numeric' }); // e.g. '482913'
+randomString(4, { charset: 'ABC123' }); // custom charset, e.g. 'A1C3'
+```
+
+**Edge Cases:**
+
+- Returns `''` (not the shared `'Please provide a valid input text'` error string) for a non-positive or non-integer `length`, and for an empty resolved charset — an empty string is itself a valid, unsurprising answer to "generate zero characters" or "pick from zero options."
+- A repeated character in a custom charset (e.g. `'AAB'`) is picked from as-is, not deduplicated — this is the caller's own way of weighting that character more heavily, not a bug.
+- Uses rejection sampling internally rather than a plain `randomUint32 % charset.length`, so every character in the charset has exactly equal probability regardless of the charset's length — a plain modulo would introduce a slight, easy-to-miss bias toward the low end of the charset for almost any length.

--- a/src/text/randomString.ts
+++ b/src/text/randomString.ts
@@ -1,0 +1,77 @@
+const alphaChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const numericChars = '0123456789';
+const alphanumericChars = alphaChars + numericChars;
+
+function resolveCharset(charset: string): string {
+  switch (charset) {
+    case 'alpha':
+      return alphaChars;
+    case 'numeric':
+      return numericChars;
+    case 'alphanumeric':
+      return alphanumericChars;
+    default:
+      // Anything else is treated as a literal, caller-supplied charset
+      // (e.g. 'ABC123') -- picked from as-is, repeats and all, rather than
+      // deduplicated, since a repeated character is the caller's own way
+      // of weighting it more heavily.
+      return charset;
+  }
+}
+
+// Draws a uniformly-distributed integer in [0, max) using rejection
+// sampling, rather than `randomUint32 % max` -- a plain modulo introduces a
+// slight bias toward the low end of the range whenever `max` doesn't evenly
+// divide 2^32 (true for almost any charset length), which would quietly
+// undercut the "cryptographically secure" claim this function makes. The
+// rejection probability is negligible for any realistic charset (well
+// under 1 in a billion for a 62-character alphanumeric set).
+function randomIndex(max: number): number {
+  const range = 0x100000000; // 2^32
+  const limit = range - (range % max);
+  const buffer = new Uint32Array(1);
+
+  let value: number;
+  do {
+    globalThis.crypto.getRandomValues(buffer);
+    value = buffer[0];
+  } while (value >= limit);
+
+  return value % max;
+}
+
+/**
+ * Generates a random string of a given length, drawn from a
+ * cryptographically secure source (`globalThis.crypto.getRandomValues`,
+ * the standard Web Crypto API available in both Node and browsers --
+ * nothing here falls back to `Math.random`). Suitable for one-off IDs,
+ * tokens, or test fixtures.
+ *
+ * @param length Number of characters to generate. Returns `''` for a
+ * non-positive or non-integer length.
+ * @param options.charset `'alpha'` (letters only), `'numeric'` (digits
+ * only), `'alphanumeric'` (the default), or any other string, which is
+ * used literally as the pool of characters to draw from (e.g. `'ABC123'`).
+ * @returns A random string of the requested length, or `''` if `length`
+ * or the resolved charset is empty.
+ * @example
+ * randomString(8); // e.g. 'aZ3kD9pQ' (alphanumeric by default)
+ * randomString(6, { charset: 'numeric' }); // e.g. '482913'
+ * randomString(4, { charset: 'ABC123' }); // custom charset, e.g. 'A1C3'
+ */
+export function randomString(
+  length: number,
+  options: { charset?: 'alpha' | 'numeric' | 'alphanumeric' | string } = {},
+): string {
+  if (!Number.isInteger(length) || length <= 0) return '';
+
+  const chars = resolveCharset(options.charset ?? 'alphanumeric');
+  if (chars.length === 0) return '';
+
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += chars[randomIndex(chars.length)];
+  }
+
+  return result;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -15,6 +15,7 @@ import { extractEmails, extractHashtags, extractMentions, extractUrls } from './
 import { escapeHtml, unescapeHtml } from './text/html';
 import { isPalindrome } from './text/isPalindrome';
 import { maskText } from './text/mask';
+import { randomString } from './text/randomString';
 import { redact } from './text/redact';
 import { reverse } from './text/reverse';
 import { spread } from './text/spread';
@@ -49,6 +50,7 @@ export {
   maskText,
   numbersToWords,
   pascalCase,
+  randomString,
   redact,
   reverse,
   slugify,

--- a/tests/Text/randomString.test.ts
+++ b/tests/Text/randomString.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { randomString } from '../../src/text/randomString';
+
+describe('#randomString', () => {
+  it('generates a string of the requested length', () => {
+    expect(randomString(8)).toHaveLength(8);
+    expect(randomString(1)).toHaveLength(1);
+    expect(randomString(32)).toHaveLength(32);
+  });
+
+  it('defaults to an alphanumeric charset', () => {
+    expect(randomString(200)).toMatch(/^[A-Za-z0-9]+$/);
+  });
+
+  it('only uses letters for the alpha charset', () => {
+    expect(randomString(200, { charset: 'alpha' })).toMatch(/^[A-Za-z]+$/);
+  });
+
+  it('only uses digits for the numeric charset', () => {
+    expect(randomString(200, { charset: 'numeric' })).toMatch(/^[0-9]+$/);
+  });
+
+  it('draws only from a custom charset', () => {
+    expect(randomString(200, { charset: 'AB' })).toMatch(/^[AB]+$/);
+  });
+
+  it('produces different output across calls (not deterministic)', () => {
+    const a = randomString(32);
+    const b = randomString(32);
+    expect(a).not.toBe(b);
+  });
+
+  it('returns an empty string for a zero length', () => {
+    expect(randomString(0)).toBe('');
+  });
+
+  it('returns an empty string for a negative length', () => {
+    expect(randomString(-5)).toBe('');
+  });
+
+  it('returns an empty string for a non-integer length', () => {
+    expect(randomString(3.5)).toBe('');
+  });
+
+  it('returns an empty string when the custom charset is empty', () => {
+    expect(randomString(5, { charset: '' })).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #295.

Adds `randomString(length, options?)`, generating a random string for one-off IDs, tokens, or test fixtures.

The issue's central scoping concern was avoiding an under-documented security footgun -- resolved by making this **cryptographically secure by default, with no insecure fallback**: it's built on `globalThis.crypto.getRandomValues` (the standard Web Crypto API, available natively in both Node ≥19 and every modern browser), not `Math.random`. This also stays consistent with the project's existing runtime-agnostic design (per docs/ARCHITECTURE.md, only `cli.ts`/`bin/` may depend on Node built-ins) since Web Crypto isn't a Node-specific import.

```ts
randomString(8); // e.g. 'aZ3kD9pQ' (alphanumeric by default)
randomString(6, { charset: 'numeric' }); // e.g. '482913'
randomString(4, { charset: 'ABC123' }); // custom charset, e.g. 'A1C3'
```

Also uses rejection sampling rather than a plain `randomUint32 % charset.length`, so every character in the charset has exactly equal probability -- a plain modulo would introduce a slight, easy-to-miss bias for almost any charset length.

New `Generation` category added to the docs (`docs/api/generation.md`) since this didn't fit any existing one.