### PR TITLE
feat: add pluralize(word, count?) function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
 - Generation: cryptographically secure random strings for IDs, tokens, or test fixtures
+- Grammar: pluralize English words for UI copy like "1 item" / "5 items"
 - Pure, dependency-free, and TypeScript-ready
 
 ---
@@ -144,6 +145,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words   |
 | `randomString(length, options?)`             | Generate a cryptographically secure random string     |
+| `pluralize(word, count?)`                    | Return the plural form of an English word             |
 | `isEmail(text)`                              | Validate an email address                             |
 | `isUrl(text)`                                | Validate a URL                                        |
 | `isPhoneNumber(text)`                        | Validate a phone number                               |

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
 - [**Generation**](api/generation.md) — [randomString](#randomstring)
+- [**Grammar**](api/grammar.md) — [pluralize](#pluralize)
 
 ---
 
@@ -166,3 +167,11 @@ Full docs: [docs/api/numbers.md#numberstowords](api/numbers.md#numberstowords)
 ### randomString
 
 Full docs: [docs/api/generation.md#randomstring](api/generation.md#randomstring)
+
+---
+
+## Grammar
+
+### pluralize
+
+Full docs: [docs/api/grammar.md#pluralize](api/grammar.md#pluralize)

--- a/docs/api/grammar.md
+++ b/docs/api/grammar.md
@@ -1,0 +1,39 @@
+# Grammar
+
+`pluralize`.
+
+---
+
+## pluralize
+
+Returns the plural form of an English word. Useful for UI copy like `` `${count} ${pluralize('item', count)}` ``.
+
+This is a documented, honest subset of English pluralization, not a complete linguistic solution — regular suffix rules (`-s`, `-es`, `-ies`) plus a maintained list of the most common irregulars and uncountable nouns.
+
+**Parameters:**
+
+- `word: string` — The singular word to pluralize.
+- `count?: number` — If provided, returns `word` unchanged when `count === 1`; any other value (including `0`, negative, or omitted) returns the plural form, matching standard English usage ("0 items", "1 item").
+
+**Returns:**
+
+- `string` — The pluralized (or singular, if `count === 1`) form of `word`, or an error message for invalid input.
+
+**Example:**
+
+```js
+import { pluralize } from 'textconvert';
+
+pluralize('cat'); // 'cats'
+pluralize('cat', 1); // 'cat'
+pluralize('cat', 5); // 'cats'
+pluralize('child'); // 'children'
+pluralize('box'); // 'boxes'
+```
+
+**Edge Cases:**
+
+- Returns `'Please provide a valid input text'` for empty input, matching the sentinel-return convention every other string-returning function in this library follows.
+- Uncountable nouns (`sheep`, `fish`, `species`, etc.) are returned unchanged regardless of `count`.
+- Does not cover every irregular — notably, Greek-derived `-ch` words pronounced /k/ (`stomach` → `stomachs`, not `stomaches`) and consonant-doubling irregulars (`quiz` → `quizzes`, not `quizes`) fall through to the regular suffix rules and produce an incorrect result. Only the maintained irregulars list in `src/text/pluralize.ts` is handled correctly.
+- Preserves the input's leading capitalization (`Child` → `Children`), but does not attempt to preserve casing beyond the first letter (e.g. all-caps input isn't specially handled).

--- a/src/text/pluralize.ts
+++ b/src/text/pluralize.ts
@@ -1,0 +1,113 @@
+// Common irregular plurals -- not exhaustive, just frequent enough in
+// everyday English to be worth a lookup rather than silently producing a
+// wrong regular-rule guess (e.g. "childs", "mouses"). Keys are lowercase;
+// the input's leading capitalization is reapplied to the result.
+const irregulars: Record<string, string> = {
+  child: 'children',
+  person: 'people',
+  man: 'men',
+  woman: 'women',
+  mouse: 'mice',
+  goose: 'geese',
+  tooth: 'teeth',
+  foot: 'feet',
+  ox: 'oxen',
+  cactus: 'cacti',
+  focus: 'foci',
+  fungus: 'fungi',
+  analysis: 'analyses',
+  crisis: 'crises',
+  criterion: 'criteria',
+  phenomenon: 'phenomena',
+  datum: 'data',
+  leaf: 'leaves',
+  knife: 'knives',
+  wife: 'wives',
+  life: 'lives',
+  half: 'halves',
+  calf: 'calves',
+  shelf: 'shelves',
+  wolf: 'wolves',
+  loaf: 'loaves',
+  thief: 'thieves',
+  self: 'selves',
+  elf: 'elves',
+  potato: 'potatoes',
+  tomato: 'tomatoes',
+  hero: 'heroes',
+  echo: 'echoes',
+};
+
+// Uncountable nouns: the same word is both singular and plural.
+const uncountables = new Set([
+  'sheep',
+  'fish',
+  'deer',
+  'moose',
+  'series',
+  'species',
+  'aircraft',
+  'salmon',
+  'trout',
+  'swine',
+  'bison',
+  'buffalo',
+]);
+
+const vowels = new Set('aeiouAEIOU');
+
+// Recapitalizes `target` to match whether `source`'s first character was
+// uppercase -- e.g. matchCase('Child', 'children') -> 'Children'. Does not
+// attempt to preserve all-caps or any casing beyond the first letter.
+function matchCase(source: string, target: string): string {
+  if (/[A-Z]/.test(source[0])) return target[0].toUpperCase() + target.slice(1);
+  return target;
+}
+
+function pluralizeRegular(word: string): string {
+  const lower = word.toLowerCase();
+
+  if (/(?:s|x|z|ch|sh)$/.test(lower)) return `${word}es`;
+
+  if (lower.endsWith('y') && word.length > 1 && !vowels.has(word[word.length - 2])) {
+    return `${word.slice(0, -1)}ies`;
+  }
+
+  return `${word}s`;
+}
+
+/**
+ * Returns the plural form of an English word. Useful for UI copy like
+ * `` `${count} ${pluralize('item', count)}` ``.
+ *
+ * This is a documented, honest subset of English pluralization, not a
+ * complete linguistic solution — regular suffix rules (-s, -es, -ies)
+ * plus a maintained list of the most common irregulars and uncountable
+ * nouns. It does not cover every irregular (e.g. Greek-derived "-ch"
+ * words pronounced /k/ like "stomach" → "stomachs", not "stomaches"), or
+ * consonant-doubling irregulars (e.g. "quiz" → "quizzes", not "quizes").
+ *
+ * @param word The singular word to pluralize.
+ * @param count If provided, returns `word` unchanged when `count === 1`;
+ * any other value (including `0`, negative, or omitted) returns the
+ * plural form, matching standard English usage ("0 items", "1 item").
+ * @returns The pluralized (or singular, if `count === 1`) form of `word`.
+ * @example
+ * pluralize('cat'); // 'cats'
+ * pluralize('cat', 1); // 'cat'
+ * pluralize('cat', 5); // 'cats'
+ * pluralize('child'); // 'children'
+ * pluralize('box'); // 'boxes'
+ */
+export function pluralize(word: string, count?: number): string {
+  if (!word) return 'Please provide a valid input text';
+  if (count === 1) return word;
+
+  const lower = word.toLowerCase();
+  if (uncountables.has(lower)) return word;
+
+  const irregular = irregulars[lower];
+  if (irregular) return matchCase(word, irregular);
+
+  return pluralizeRegular(word);
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -16,6 +16,7 @@ import { extractEmails, extractHashtags, extractMentions, extractUrls } from './
 import { escapeHtml, unescapeHtml } from './text/html';
 import { isPalindrome } from './text/isPalindrome';
 import { maskText } from './text/mask';
+import { pluralize } from './text/pluralize';
 import { randomString } from './text/randomString';
 import { redact } from './text/redact';
 import { reverse } from './text/reverse';
@@ -51,6 +52,7 @@ export {
   maskText,
   numbersToWords,
   pascalCase,
+  pluralize,
   randomString,
   redact,
   reverse,

--- a/tests/Text/pluralize.test.ts
+++ b/tests/Text/pluralize.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { pluralize } from '../../src/text/pluralize';
+
+describe('#pluralize', () => {
+  it('pluralizes a regular word by default', () => {
+    expect(pluralize('cat')).toBe('cats');
+  });
+
+  it('returns the singular form for count 1', () => {
+    expect(pluralize('cat', 1)).toBe('cat');
+  });
+
+  it('returns the plural form for count other than 1', () => {
+    expect(pluralize('cat', 5)).toBe('cats');
+    expect(pluralize('cat', 0)).toBe('cats');
+    expect(pluralize('cat', -3)).toBe('cats');
+  });
+
+  it('adds -es for words ending in s, x, z, ch, sh', () => {
+    expect(pluralize('bus')).toBe('buses');
+    expect(pluralize('box')).toBe('boxes');
+    expect(pluralize('buzz')).toBe('buzzes');
+    expect(pluralize('beach')).toBe('beaches');
+    expect(pluralize('wish')).toBe('wishes');
+  });
+
+  it('changes consonant+y to -ies', () => {
+    expect(pluralize('city')).toBe('cities');
+  });
+
+  it('keeps vowel+y and just adds -s', () => {
+    expect(pluralize('boy')).toBe('boys');
+    expect(pluralize('day')).toBe('days');
+  });
+
+  it('handles known irregular plurals', () => {
+    expect(pluralize('child')).toBe('children');
+    expect(pluralize('person')).toBe('people');
+    expect(pluralize('mouse')).toBe('mice');
+    expect(pluralize('tooth')).toBe('teeth');
+  });
+
+  it('handles known -f/-fe -> -ves irregulars', () => {
+    expect(pluralize('leaf')).toBe('leaves');
+    expect(pluralize('knife')).toBe('knives');
+    expect(pluralize('wolf')).toBe('wolves');
+  });
+
+  it('handles known -o -> -oes irregulars', () => {
+    expect(pluralize('potato')).toBe('potatoes');
+    expect(pluralize('hero')).toBe('heroes');
+  });
+
+  it('returns uncountable nouns unchanged', () => {
+    expect(pluralize('sheep')).toBe('sheep');
+    expect(pluralize('fish')).toBe('fish');
+    expect(pluralize('species')).toBe('species');
+  });
+
+  it('preserves leading capitalization on irregulars', () => {
+    expect(pluralize('Child')).toBe('Children');
+  });
+
+  it('preserves leading capitalization on regular words', () => {
+    expect(pluralize('City')).toBe('Cities');
+    expect(pluralize('Box')).toBe('Boxes');
+  });
+
+  it('returns the shared invalid-input message for empty input', () => {
+    expect(pluralize('')).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
Closes #297.

Adds `pluralize(word, count?)` for UI copy like `` `${count} ${pluralize('item', count)}` ``.

Follows the honest-scope approach the issue asked for: regular suffix rules (`-s`, `-es`, `-ies`) plus a maintained list of the most common irregulars (`child`→`children`, `leaf`→`leaves`, `potato`→`potatoes`, etc.) and uncountable nouns (`sheep`, `fish`, `species`), rather than a silent claim of full coverage.

```ts
pluralize('cat');     // 'cats'
pluralize('cat', 1);  // 'cat'
pluralize('child');   // 'children'
pluralize('box');     // 'boxes'
```

Explicitly documents (JSDoc + the new `docs/api/grammar.md` entry) the two known gaps the issue flagged as worth deciding rather than leaving ambiguous: Greek-derived `-ch` words pronounced /k/ (`stomach` → would incorrectly produce `stomaches`) and consonant-doubling irregulars (`quiz` → would incorrectly produce `quizes`). Neither is in the maintained irregulars list, so both fall through to the regular rule and produce a documented-as-wrong result rather than a silent one.

New `Grammar` category added to the docs (`docs/api/grammar.md`), separate from `Case Conversion` since this is a linguistic operation, not a formatting one.