### PR TITLE
feat: add readability scoring to getTextStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify, capitalize, Title Case
 - Validation: email addresses, URLs, and phone numbers
 - Extraction: pull email addresses, URLs, @mentions, and #hashtags out of a block of text
-- Text analysis: word/letter/sentence/paragraph counting, reading time, palindrome checking, word frequency, etc.
+- Text analysis: word/letter/sentence/paragraph counting, reading time, readability scoring, palindrome checking, word frequency, etc.
 - Text utilities: truncate with word-boundary awareness
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
@@ -121,40 +121,40 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 
 ## 📋 API Reference
 
-| Function                                     | Description                                           |
-| -------------------------------------------- | ----------------------------------------------------- |
-| `camelCase(text)`                            | Convert to camelCase                                  |
-| `pascalCase(text)`                           | Convert to PascalCase                                 |
-| `snakeCase(text)`                            | Convert to snake_case                                 |
-| `kebabCase(text)`                            | Convert to kebab-case                                 |
-| `slugify(text)`                              | Convert to a URL-safe slug                            |
-| `capitalize(text)`                           | Capitalize only the first letter                      |
-| `titleCase(text)`                            | Capitalize the first letter of every word             |
-| `clear(text)`                                | Remove punctuation from text                          |
-| `count(text, countNumbers?)`                 | Count letters (optionally including numbers)          |
-| `countWords(text)`                           | Count words                                           |
-| `countSentences(text)`                       | Count sentences                                       |
-| `reverse(text)`                              | Reverse a string                                      |
-| `spread(text, clear?)`                       | Split a string into an array of characters            |
-| `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis        |
-| `maskText(text, options?)`                   | Partially mask a string for display                   |
-| `redact(text, options?)`                     | Mask PII/secrets embedded in text                     |
-| `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time) |
-| `isPalindrome(text)`                         | Check if text is a palindrome                         |
-| `wordFrequency(text)`                        | Count how many times each word appears                |
-| `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                |
-| `numbersToWords(number)`                     | Convert a number under 100 million to English words   |
-| `randomString(length, options?)`             | Generate a cryptographically secure random string     |
-| `pluralize(word, count?)`                    | Return the plural form of an English word             |
-| `isEmail(text)`                              | Validate an email address                             |
-| `isUrl(text)`                                | Validate a URL                                        |
-| `isPhoneNumber(text)`                        | Validate a phone number                               |
-| `extractEmails(text)`                        | Extract all email addresses found in a block of text  |
-| `extractUrls(text)`                          | Extract all URLs found in a block of text             |
-| `extractMentions(text)`                      | Extract all @mentions found in a block of text        |
-| `extractHashtags(text)`                      | Extract all #hashtags found in a block of text        |
-| `escapeHtml(text)`                           | Escape the five HTML special characters               |
-| `unescapeHtml(text)`                         | Reverse `escapeHtml`'s escaping                       |
+| Function                                     | Description                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------ |
+| `camelCase(text)`                            | Convert to camelCase                                               |
+| `pascalCase(text)`                           | Convert to PascalCase                                              |
+| `snakeCase(text)`                            | Convert to snake_case                                              |
+| `kebabCase(text)`                            | Convert to kebab-case                                              |
+| `slugify(text)`                              | Convert to a URL-safe slug                                         |
+| `capitalize(text)`                           | Capitalize only the first letter                                   |
+| `titleCase(text)`                            | Capitalize the first letter of every word                          |
+| `clear(text)`                                | Remove punctuation from text                                       |
+| `count(text, countNumbers?)`                 | Count letters (optionally including numbers)                       |
+| `countWords(text)`                           | Count words                                                        |
+| `countSentences(text)`                       | Count sentences                                                    |
+| `reverse(text)`                              | Reverse a string                                                   |
+| `spread(text, clear?)`                       | Split a string into an array of characters                         |
+| `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis                     |
+| `maskText(text, options?)`                   | Partially mask a string for display                                |
+| `redact(text, options?)`                     | Mask PII/secrets embedded in text                                  |
+| `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time, readability) |
+| `isPalindrome(text)`                         | Check if text is a palindrome                                      |
+| `wordFrequency(text)`                        | Count how many times each word appears                             |
+| `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                             |
+| `numbersToWords(number)`                     | Convert a number under 100 million to English words                |
+| `randomString(length, options?)`             | Generate a cryptographically secure random string                  |
+| `pluralize(word, count?)`                    | Return the plural form of an English word                          |
+| `isEmail(text)`                              | Validate an email address                                          |
+| `isUrl(text)`                                | Validate a URL                                                     |
+| `isPhoneNumber(text)`                        | Validate a phone number                                            |
+| `extractEmails(text)`                        | Extract all email addresses found in a block of text               |
+| `extractUrls(text)`                          | Extract all URLs found in a block of text                          |
+| `extractMentions(text)`                      | Extract all @mentions found in a block of text                     |
+| `extractHashtags(text)`                      | Extract all #hashtags found in a block of text                     |
+| `escapeHtml(text)`                           | Escape the five HTML special characters                            |
+| `unescapeHtml(text)`                         | Reverse `escapeHtml`'s escaping                                    |
 
 See [docs/API.md](docs/API.md) for full parameter, return type, and edge-case details on every function, or browse the auto-generated [API reference site](https://monsieur-nico.github.io/textConvert/).
 

--- a/docs/api/text-analysis.md
+++ b/docs/api/text-analysis.md
@@ -148,19 +148,21 @@ Analyzes text and returns comprehensive statistics.
 
 `TextStatistics` — an object with:
 
-| Field                    | Type     | Meaning                                                             |
-| ------------------------ | -------- | ------------------------------------------------------------------- |
-| `characterCount`         | `number` | Total characters, including whitespace and punctuation.             |
-| `characterCountNoSpaces` | `number` | Characters excluding whitespace.                                    |
-| `letterCount`            | `number` | Alphabetic characters only (same rule as `count`).                  |
-| `alphanumericCount`      | `number` | Letters and digits (same rule as `count(text, true)`).              |
-| `wordCount`              | `number` | Same rule as `countWords`.                                          |
-| `sentenceCount`          | `number` | Same rule as `countSentences`.                                      |
-| `paragraphCount`         | `number` | Blocks of text separated by 2 or more consecutive newlines.         |
-| `averageWordLength`      | `number` | Mean alphanumeric characters per word, rounded to 1 decimal.        |
-| `averageSentenceLength`  | `number` | Mean words per sentence, rounded to 1 decimal.                      |
-| `readingTimeSeconds`     | `number` | `wordCount / (wordsPerMinute / 60)`, rounded to the nearest second. |
-| `readingTimeFormatted`   | `string` | Human-readable reading time, e.g. `'2 min 30 sec'` or `'45 sec'`.   |
+| Field                    | Type     | Meaning                                                              |
+| ------------------------ | -------- | -------------------------------------------------------------------- |
+| `characterCount`         | `number` | Total characters, including whitespace and punctuation.              |
+| `characterCountNoSpaces` | `number` | Characters excluding whitespace.                                     |
+| `letterCount`            | `number` | Alphabetic characters only (same rule as `count`).                   |
+| `alphanumericCount`      | `number` | Letters and digits (same rule as `count(text, true)`).               |
+| `wordCount`              | `number` | Same rule as `countWords`.                                           |
+| `sentenceCount`          | `number` | Same rule as `countSentences`.                                       |
+| `paragraphCount`         | `number` | Blocks of text separated by 2 or more consecutive newlines.          |
+| `averageWordLength`      | `number` | Mean alphanumeric characters per word, rounded to 1 decimal.         |
+| `averageSentenceLength`  | `number` | Mean words per sentence, rounded to 1 decimal.                       |
+| `readingTimeSeconds`     | `number` | `wordCount / (wordsPerMinute / 60)`, rounded to the nearest second.  |
+| `readingTimeFormatted`   | `string` | Human-readable reading time, e.g. `'2 min 30 sec'` or `'45 sec'`.    |
+| `fleschReadingEase`      | `number` | Flesch Reading Ease score — higher is easier to read, roughly 0-100. |
+| `fleschKincaidGrade`     | `number` | Flesch-Kincaid Grade Level — approximate U.S. school grade needed.   |
 
 **Example:**
 
@@ -170,16 +172,18 @@ import { getTextStats } from 'textconvert';
 getTextStats('Hello world! This is a test.');
 // {
 //   characterCount: 28,
-//   characterCountNoSpaces: 24,
-//   letterCount: 20,
-//   alphanumericCount: 20,
+//   characterCountNoSpaces: 23,
+//   letterCount: 21,
+//   alphanumericCount: 21,
 //   wordCount: 6,
 //   sentenceCount: 2,
 //   paragraphCount: 1,
-//   averageWordLength: 3.3,
+//   averageWordLength: 3.5,
 //   averageSentenceLength: 3,
 //   readingTimeSeconds: 2,
-//   readingTimeFormatted: '2 sec'
+//   readingTimeFormatted: '2 sec',
+//   fleschReadingEase: 105.1,
+//   fleschKincaidGrade: -0.7
 // }
 ```
 
@@ -188,6 +192,7 @@ getTextStats('Hello world! This is a test.');
 - Returns all numeric fields as 0 and `readingTimeFormatted: '0 sec'` for empty (or whitespace-only) input.
 - `paragraphCount` is never less than 1 for non-empty input, even if there isn't a single blank-line-separated break.
 - Built from the other analysis functions internally (`count`, `countWords`, `countSentences`) rather than re-implementing their rules, so anything documented as an edge case for those applies here too.
+- `fleschReadingEase`/`fleschKincaidGrade` both depend on a syllable-count **heuristic** (vowel-group counting, not a dictionary lookup) — it gets common words right (`table` → 2, `beautiful` → 3) but is known to misestimate real irregulars (e.g. `rhythm`). Treat both scores as estimates, not precise measurements, especially on short or unusual text — the formulas can also produce values outside their "typical" 0-100 / grade-level ranges (e.g. a negative grade level on very short, simple text, as in the example above).
 
 ---
 

--- a/src/text/analysis/statistics.ts
+++ b/src/text/analysis/statistics.ts
@@ -58,6 +58,47 @@ export interface TextStatistics {
    * Estimated reading time as formatted string (e.g., "2 min 30 sec")
    */
   readingTimeFormatted: string;
+
+  /**
+   * Flesch Reading Ease score (higher is easier to read; roughly 0-100,
+   * though the formula can produce values outside that range for unusual
+   * text). Estimated from word/sentence counts and a syllable-count
+   * heuristic -- see {@link estimateSyllables}'s documentation for its
+   * known accuracy limits.
+   */
+  fleschReadingEase: number;
+
+  /**
+   * Flesch-Kincaid Grade Level score (approximate U.S. school grade level
+   * needed to understand the text). Subject to the same syllable-estimate
+   * accuracy limits as {@link fleschReadingEase}.
+   */
+  fleschKincaidGrade: number;
+}
+
+// Estimates a word's syllable count by counting vowel groups (a run of
+// consecutive vowels counts as one syllable), adjusting for a silent
+// trailing 'e' (e.g. "like" is one syllable, not two). This is a cheap
+// heuristic, not a dictionary lookup -- it gets simple, common words right
+// ("cat" -> 1, "table" -> 2, "beautiful" -> 3) but is known to
+// misestimate real irregulars (e.g. "rhythm", which has no written vowel
+// in its second syllable). Readability scores computed from it should be
+// read as estimates, not precise measurements, for exactly that reason.
+function estimateSyllables(word: string): number {
+  const lower = word.toLowerCase().replace(/[^a-z]/g, '');
+  if (!lower) return 0;
+
+  const vowelGroups = lower.match(/[aeiouy]+/g) ?? [];
+  let syllables = vowelGroups.length;
+
+  // "table" ends in "le" after a consonant, which counts as its own
+  // syllable ("ta-ble"), so only drop a trailing silent 'e' when it's NOT
+  // part of that pattern.
+  if (lower.endsWith('e') && !lower.endsWith('le') && syllables > 1) {
+    syllables--;
+  }
+
+  return Math.max(syllables, 1);
 }
 
 /**
@@ -70,16 +111,18 @@ export interface TextStatistics {
  * getTextStats('Hello world! This is a test.');
  * // {
  * //   characterCount: 28,
- * //   characterCountNoSpaces: 24,
- * //   letterCount: 20,
- * //   alphanumericCount: 20,
+ * //   characterCountNoSpaces: 23,
+ * //   letterCount: 21,
+ * //   alphanumericCount: 21,
  * //   wordCount: 6,
  * //   sentenceCount: 2,
  * //   paragraphCount: 1,
- * //   averageWordLength: 3.3,
+ * //   averageWordLength: 3.5,
  * //   averageSentenceLength: 3,
  * //   readingTimeSeconds: 2,
- * //   readingTimeFormatted: '2 sec'
+ * //   readingTimeFormatted: '2 sec',
+ * //   fleschReadingEase: 105.1,
+ * //   fleschKincaidGrade: -0.7
  * // }
  */
 export function getTextStats(text: string, wordsPerMinute: number = 200): TextStatistics {
@@ -97,6 +140,8 @@ export function getTextStats(text: string, wordsPerMinute: number = 200): TextSt
       averageSentenceLength: 0,
       readingTimeSeconds: 0,
       readingTimeFormatted: '0 sec',
+      fleschReadingEase: 0,
+      fleschKincaidGrade: 0,
     };
   }
 
@@ -125,6 +170,27 @@ export function getTextStats(text: string, wordsPerMinute: number = 200): TextSt
   const averageSentenceLength =
     sentenceCount > 0 ? Math.round((wordCount / sentenceCount) * 10) / 10 : 0;
 
+  // Readability scores (Flesch Reading Ease / Flesch-Kincaid Grade Level),
+  // both needing a total syllable count across the same word list used
+  // for averageWordLength above.
+  let totalSyllables = 0;
+  for (const word of words) {
+    const cleaned = word.replace(/[^a-zA-Z]/g, '');
+    if (cleaned) totalSyllables += estimateSyllables(cleaned);
+  }
+
+  const canScore = wordCount > 0 && sentenceCount > 0;
+  const wordsPerSentence = canScore ? wordCount / sentenceCount : 0;
+  const syllablesPerWord = canScore ? totalSyllables / wordCount : 0;
+
+  const fleschReadingEase = canScore
+    ? Math.round((206.835 - 1.015 * wordsPerSentence - 84.6 * syllablesPerWord) * 10) / 10
+    : 0;
+
+  const fleschKincaidGrade = canScore
+    ? Math.round((0.39 * wordsPerSentence + 11.8 * syllablesPerWord - 15.59) * 10) / 10
+    : 0;
+
   // Calculate reading time
   const wordsPerSecond = wordsPerMinute / 60;
   const readingTimeSeconds = Math.round(wordCount / wordsPerSecond);
@@ -144,6 +210,8 @@ export function getTextStats(text: string, wordsPerMinute: number = 200): TextSt
     averageSentenceLength,
     readingTimeSeconds,
     readingTimeFormatted,
+    fleschReadingEase,
+    fleschKincaidGrade,
   };
 }
 

--- a/tests/Text/Analysis/statistics.test.ts
+++ b/tests/Text/Analysis/statistics.test.ts
@@ -103,4 +103,33 @@ describe('#getTextStats', () => {
     const stats = getTextStats('Hello123 world!');
     expect(stats.alphanumericCount).toBe(13);
   });
+
+  it('should calculate readability scores for simple text', () => {
+    const stats = getTextStats('The cat sat on the mat. It was a sunny day.');
+    expect(stats.fleschReadingEase).toBe(109);
+    expect(stats.fleschKincaidGrade).toBe(-0.6);
+  });
+
+  it('should return 0 for both readability scores on empty input', () => {
+    const stats = getTextStats('');
+    expect(stats.fleschReadingEase).toBe(0);
+    expect(stats.fleschKincaidGrade).toBe(0);
+  });
+
+  it('should return 0 for both readability scores when there are no words', () => {
+    const stats = getTextStats('!!!...???');
+    expect(stats.fleschReadingEase).toBe(0);
+    expect(stats.fleschKincaidGrade).toBe(0);
+  });
+
+  it('should allow readability scores outside their typical ranges for unusual text', () => {
+    // Long, multi-syllable words with few sentences push the formulas well
+    // past their "typical" 0-100 / grade-level ranges -- this is expected
+    // behavior (see the docs' honesty caveat), not a bug to clamp away.
+    const stats = getTextStats(
+      'Extraordinary international communication requires substantial vocabulary comprehension.',
+    );
+    expect(stats.fleschReadingEase).toBeLessThan(0);
+    expect(stats.fleschKincaidGrade).toBeGreaterThan(12);
+  });
 });


### PR DESCRIPTION
Closes #327.

Extends `getTextStats`'s return shape with two new fields -- additive, not a new function, so no existing consumer's output changes:

```ts
const stats = getTextStats('The cat sat on the mat. It was a sunny day.');
stats.fleschReadingEase;   // 109
stats.fleschKincaidGrade;  // -0.6
```

Both formulas need a syllable-count estimate per word. Per the issue's own framing of the tradeoff, went with the cheap option: a vowel-group heuristic (count runs of vowels, with a silent-trailing-`e` adjustment) rather than a larger exception-list approach -- consistent with the project's dependency-free, low-maintenance-surface philosophy. This is documented honestly as an **estimate**, not a precise measurement (JSDoc + the category doc's edge cases), including a concrete example of where it's known to misestimate (`rhythm`) and where the formulas themselves can produce values outside their "typical" ranges (verified with a real example in the tests: long multi-syllable words push `fleschReadingEase` negative and `fleschKincaidGrade` past 12).

Also fixed a pre-existing, unrelated staleness bug I found while touching this same docstring: the old `@example` block's numbers (`characterCountNoSpaces: 24`, `letterCount: 20`, etc.) no longer matched the function's actual output. Recomputed and corrected in both the JSDoc and `docs/api/text-analysis.md`.