### PR TITLE
feat: add standalone Unicode/whitespace normalization functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Number to words: Converts numbers < 100 million to English words
 - Generation: cryptographically secure random strings for IDs, tokens, or test fixtures
 - Grammar: pluralize English words for UI copy like "1 item" / "5 items"
+- Normalization: strip diacritics, collapse whitespace, and normalize line endings
 - Pure, dependency-free, and TypeScript-ready
 
 ---
@@ -146,6 +147,9 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words                |
 | `randomString(length, options?)`             | Generate a cryptographically secure random string                  |
 | `pluralize(word, count?)`                    | Return the plural form of an English word                          |
+| `removeDiacritics(text)`                     | Strip accents from accented characters                             |
+| `normalizeWhitespace(text)`                  | Collapse whitespace runs into a single space                       |
+| `normalizeLineEndings(text)`                 | Normalize CRLF/CR line endings to LF                               |
 | `isEmail(text)`                              | Validate an email address                                          |
 | `isUrl(text)`                                | Validate a URL                                                     |
 | `isPhoneNumber(text)`                        | Validate a phone number                                            |

--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
 - [**Generation**](api/generation.md) — [randomString](#randomstring)
 - [**Grammar**](api/grammar.md) — [pluralize](#pluralize)
+- [**Normalization**](api/normalization.md) — [removeDiacritics](#removediacritics), [normalizeWhitespace](#normalizewhitespace), [normalizeLineEndings](#normalizelineendings)
 
 ---
 
@@ -175,3 +176,19 @@ Full docs: [docs/api/generation.md#randomstring](api/generation.md#randomstring)
 ### pluralize
 
 Full docs: [docs/api/grammar.md#pluralize](api/grammar.md#pluralize)
+
+---
+
+## Normalization
+
+### removeDiacritics
+
+Full docs: [docs/api/normalization.md#removediacritics](api/normalization.md#removediacritics)
+
+### normalizeWhitespace
+
+Full docs: [docs/api/normalization.md#normalizewhitespace](api/normalization.md#normalizewhitespace)
+
+### normalizeLineEndings
+
+Full docs: [docs/api/normalization.md#normalizelineendings](api/normalization.md#normalizelineendings)

--- a/docs/api/normalization.md
+++ b/docs/api/normalization.md
@@ -1,0 +1,92 @@
+# Normalization
+
+`removeDiacritics`, `normalizeWhitespace`, `normalizeLineEndings`.
+
+---
+
+## Table of Contents
+
+- [removeDiacritics](#removediacritics)
+- [normalizeWhitespace](#normalizewhitespace)
+- [normalizeLineEndings](#normalizelineendings)
+
+---
+
+## removeDiacritics
+
+Strips accents/diacritics from text, normalizing accented characters to their plain-ASCII equivalents (e.g. `é` → `e`). The same NFD-decompose-and-strip-combining-marks logic `slugify` uses internally, made standalone and reusable — `slugify` now calls this instead of duplicating it.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The text with diacritics removed.
+
+**Example:**
+
+```js
+import { removeDiacritics } from 'textconvert';
+
+removeDiacritics('Café — résumé'); // 'Cafe — resume'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Non-Latin scripts pass through unchanged — this only affects characters that decompose into a plain-ASCII base plus a combining mark under Unicode NFD (e.g. Latin accented letters), not scripts without that decomposition (Cyrillic, CJK, etc.).
+
+---
+
+## normalizeWhitespace
+
+Collapses runs of whitespace (spaces, tabs, newlines) into a single space, and trims the result.
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The text with whitespace runs collapsed to single spaces and the ends trimmed.
+
+**Example:**
+
+```js
+import { normalizeWhitespace } from 'textconvert';
+
+normalizeWhitespace('  Hello   World  \n\n'); // 'Hello World'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Collapses newlines and tabs the same as runs of spaces — this is not paragraph-aware (it doesn't preserve intentional blank lines between paragraphs the way `getTextStats`'s `paragraphCount` detects them).
+
+---
+
+## normalizeLineEndings
+
+Normalizes line endings to LF (`\n`), converting both CRLF (`\r\n`) and lone CR (`\r`) — useful for comparing or hashing text that may have come from different platforms (e.g. Windows-authored input).
+
+**Parameters:**
+
+- `text: string` — The input string.
+
+**Returns:**
+
+- `string` — The text with all line endings converted to `\n`.
+
+**Example:**
+
+```js
+import { normalizeLineEndings } from 'textconvert';
+
+normalizeLineEndings('line1\r\nline2\rline3'); // 'line1\nline2\nline3'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Text with only LF line endings already is returned unchanged.

--- a/src/text/normalize.ts
+++ b/src/text/normalize.ts
@@ -1,0 +1,53 @@
+// Matches Unicode combining diacritical marks (code points 0x0300-0x036F),
+// the marks left behind after NFD-decomposing an accented character (e.g.
+// an accented "e" decomposes into a plain "e" plus a combining mark).
+const combiningMarks = new RegExp(
+  `[${String.fromCharCode(0x0300)}-${String.fromCharCode(0x036f)}]`,
+  'g',
+);
+
+/**
+ * Strips accents/diacritics from text, normalizing accented characters to
+ * their plain-ASCII equivalents (e.g. 'é' -> 'e'). Non-Latin scripts pass
+ * through unchanged -- this only affects characters that decompose into a
+ * plain-ASCII base plus a combining mark under Unicode NFD.
+ *
+ * @param text Text to strip diacritics from.
+ * @returns The text with diacritics removed.
+ * @example
+ * removeDiacritics('Café — résumé'); // 'Cafe — resume'
+ */
+export function removeDiacritics(text: string): string {
+  if (!text) return 'Please provide a valid input text';
+  return text.normalize('NFD').replace(combiningMarks, '');
+}
+
+/**
+ * Collapses runs of whitespace (spaces, tabs, newlines) into a single
+ * space, and trims the result.
+ *
+ * @param text Text to normalize.
+ * @returns The text with whitespace runs collapsed to single spaces and
+ * the ends trimmed.
+ * @example
+ * normalizeWhitespace('  Hello   World  \n\n'); // 'Hello World'
+ */
+export function normalizeWhitespace(text: string): string {
+  if (!text) return 'Please provide a valid input text';
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Normalizes line endings to LF (`\n`), converting both CRLF (`\r\n`) and
+ * lone CR (`\r`) -- useful for comparing or hashing text that may have
+ * come from different platforms (e.g. Windows-authored input).
+ *
+ * @param text Text to normalize.
+ * @returns The text with all line endings converted to `\n`.
+ * @example
+ * normalizeLineEndings('line1\r\nline2\rline3'); // 'line1\nline2\nline3'
+ */
+export function normalizeLineEndings(text: string): string {
+  if (!text) return 'Please provide a valid input text';
+  return text.replace(/\r\n|\r/g, '\n');
+}

--- a/src/text/slugify.ts
+++ b/src/text/slugify.ts
@@ -1,14 +1,7 @@
 import { regex } from '../assets/regex';
+import { removeDiacritics } from './normalize';
 
 const { values } = regex;
-
-// Matches Unicode combining diacritical marks (code points 0x0300-0x036F),
-// the marks left behind after NFD-decomposing an accented character (e.g.
-// an accented "e" decomposes into a plain "e" plus a combining mark).
-const combiningMarks = new RegExp(
-  `[${String.fromCharCode(0x0300)}-${String.fromCharCode(0x036f)}]`,
-  'g',
-);
 
 /**
  * Convert text into a URL-safe slug: lowercase, punctuation stripped,
@@ -27,7 +20,7 @@ export function slugify(text: string): string {
 
   // Decompose accented characters (NFD) and strip the combining marks,
   // leaving plain-ASCII equivalents.
-  const normalized = text.normalize('NFD').replace(combiningMarks, '');
+  const normalized = removeDiacritics(text);
 
   // Split on runs of non-alphanumeric characters and join with "-"
   const words = normalized.toLowerCase().split(values.nonAlphaNumeric);

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -16,6 +16,7 @@ import { extractEmails, extractHashtags, extractMentions, extractUrls } from './
 import { escapeHtml, unescapeHtml } from './text/html';
 import { isPalindrome } from './text/isPalindrome';
 import { maskText } from './text/mask';
+import { normalizeLineEndings, normalizeWhitespace, removeDiacritics } from './text/normalize';
 import { pluralize } from './text/pluralize';
 import { randomString } from './text/randomString';
 import { redact } from './text/redact';
@@ -50,11 +51,14 @@ export {
   Language,
   LanguageDetectionResult,
   maskText,
+  normalizeLineEndings,
+  normalizeWhitespace,
   numbersToWords,
   pascalCase,
   pluralize,
   randomString,
   redact,
+  removeDiacritics,
   reverse,
   slugify,
   snakeCase,

--- a/tests/Text/normalize.test.ts
+++ b/tests/Text/normalize.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeLineEndings,
+  normalizeWhitespace,
+  removeDiacritics,
+} from '../../src/text/normalize';
+
+describe('#removeDiacritics', () => {
+  it('strips accents from accented characters', () => {
+    expect(removeDiacritics('Café — résumé')).toBe('Cafe — resume');
+  });
+
+  it('leaves plain ASCII text unchanged', () => {
+    expect(removeDiacritics('Hello World')).toBe('Hello World');
+  });
+
+  it('returns the shared invalid-input message for empty input', () => {
+    expect(removeDiacritics('')).toBe('Please provide a valid input text');
+  });
+});
+
+describe('#normalizeWhitespace', () => {
+  it('collapses runs of whitespace into a single space', () => {
+    expect(normalizeWhitespace('  Hello   World  \n\n')).toBe('Hello World');
+  });
+
+  it('collapses tabs and newlines too', () => {
+    expect(normalizeWhitespace('a\t\tb\n\nc')).toBe('a b c');
+  });
+
+  it('leaves already-normalized text unchanged', () => {
+    expect(normalizeWhitespace('Hello World')).toBe('Hello World');
+  });
+
+  it('returns the shared invalid-input message for empty input', () => {
+    expect(normalizeWhitespace('')).toBe('Please provide a valid input text');
+  });
+});
+
+describe('#normalizeLineEndings', () => {
+  it('converts CRLF to LF', () => {
+    expect(normalizeLineEndings('line1\r\nline2\r\nline3')).toBe('line1\nline2\nline3');
+  });
+
+  it('converts lone CR to LF', () => {
+    expect(normalizeLineEndings('line1\rline2')).toBe('line1\nline2');
+  });
+
+  it('leaves LF-only text unchanged', () => {
+    expect(normalizeLineEndings('line1\nline2')).toBe('line1\nline2');
+  });
+
+  it('handles a mix of line ending styles', () => {
+    expect(normalizeLineEndings('a\r\nb\rc\nd')).toBe('a\nb\nc\nd');
+  });
+
+  it('returns the shared invalid-input message for empty input', () => {
+    expect(normalizeLineEndings('')).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
Closes #364.

Adds three new normalization functions:

```ts
removeDiacritics('Café — résumé');       // 'Cafe — resume'
normalizeWhitespace('  Hello   World  \n\n'); // 'Hello World'
normalizeLineEndings('line1\r\nline2\rline3'); // 'line1\nline2\nline3'
```

`removeDiacritics` is the NFD-decompose-and-strip-combining-marks logic that already lived privately inside `slugify.ts` -- extracted into a standalone, reusable function rather than left duplicated wherever else it's needed. `slugify` now calls it internally instead; verified against slugify's existing test suite to confirm this refactor doesn't change its behavior.

`normalizeWhitespace` and `normalizeLineEndings` are new -- nothing in the library collapsed whitespace runs or normalized CRLF/CR before this.

New `Normalization` category added to the docs (`docs/api/normalization.md`), per the issue's own framing of these three as one cohesive module.

Per the issue's explicit scoping note, `normalizeQuotes`/`normalizeDashes` are deliberately left out of this pass -- genuinely subjective territory (a blog editor wants to keep smart quotes, a slug generator wants to strip them), worth their own issue if there's real demand rather than bundled in as an assumption.

This is also the dependency #365 (the `sanitize()` pipeline) needs for its `normalizeWhitespace` option.