### PR TITLE
feat: add a sanitize() pipeline composing existing text functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 ## ✨ Features
 
 - **PII redaction:** mask emails, phone numbers, credit card numbers, and (opt-in) API keys/tokens embedded in free-form text, or partially mask a known value for display
+- **`sanitize()` pipeline:** trim, normalize whitespace, redact PII, and escape HTML in one configurable call, composed from the functions above
 - **XSS-safe HTML escaping:** escape/unescape the five HTML special characters per OWASP's XSS Prevention Cheat Sheet, without a dedicated escaping library
 - **CLI:** `npx textconvert redact <file>` sanitizes a file (or stdin) from the command line, no JS required
 - Case conversion: camelCase, PascalCase, snake_case, kebab-case, slugify, capitalize, Title Case
@@ -159,6 +160,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `extractHashtags(text)`                      | Extract all #hashtags found in a block of text                     |
 | `escapeHtml(text)`                           | Escape the five HTML special characters                            |
 | `unescapeHtml(text)`                         | Reverse `escapeHtml`'s escaping                                    |
+| `sanitize(text, options?)`                   | Trim, normalize, redact, and escape in one configurable pipeline   |
 
 See [docs/API.md](docs/API.md) for full parameter, return type, and edge-case details on every function, or browse the auto-generated [API reference site](https://monsieur-nico.github.io/textConvert/).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Case Conversion**](api/case-conversion.md) — [camelCase](#camelcase), [pascalCase](#pascalcase), [snakeCase](#snakecase), [kebabCase](#kebabcase), [slugify](#slugify), [capitalize](#capitalize), [titleCase](#titlecase)
 - [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
 - [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls), [extractMentions](#extractmentions), [extractHashtags](#extracthashtags)
-- [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml)
+- [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml), [sanitize](#sanitize)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate), [wordFrequency](#wordfrequency)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
@@ -100,6 +100,10 @@ Full docs: [docs/api/security.md#escapehtml](api/security.md#escapehtml)
 ### unescapeHtml
 
 Full docs: [docs/api/security.md#unescapehtml](api/security.md#unescapehtml)
+
+### sanitize
+
+Full docs: [docs/api/security.md#sanitize](api/security.md#sanitize)
 
 ---
 

--- a/docs/api/security.md
+++ b/docs/api/security.md
@@ -1,6 +1,6 @@
 # Security
 
-`redact`, `maskText`, `escapeHtml`, `unescapeHtml`.
+`redact`, `maskText`, `escapeHtml`, `unescapeHtml`, `sanitize`.
 
 ---
 
@@ -10,6 +10,7 @@
 - [maskText](#masktext)
 - [escapeHtml](#escapehtml)
 - [unescapeHtml](#unescapehtml)
+- [sanitize](#sanitize)
 
 ---
 
@@ -155,3 +156,46 @@ unescapeHtml('Tom &amp; Jerry');
 - Returns an error message for empty input.
 - **Not a general-purpose HTML entity decoder.** Only the five entities `escapeHtml` produces are reversed — `&nbsp;`, `&copy;`, numeric character references like `&#65;`, and every other named or numeric entity are left untouched, by design.
 - Accepts both `&#x27;` (hex, what `escapeHtml` produces) and `&#39;` (decimal) as valid apostrophe input, plus the named `&apos;` form — even though `escapeHtml` only ever outputs `&#x27;`, so round-tripping output from other tools that use a different convention still works.
+
+---
+
+## sanitize
+
+Runs text through a configurable pipeline of `trim`, `normalizeWhitespace`, `redact`, and `escapeHtml` — composition, not new detection logic, for the common "clean this user input/log line before it's stored or displayed" case.
+
+**Parameters:**
+
+- `text: string` — The input string.
+- `options.trim?: boolean` — Trim leading/trailing whitespace.
+- `options.normalizeWhitespace?: boolean` — Collapse internal whitespace runs to a single space (also trims — see [normalization.md](normalization.md#normalizewhitespace)).
+- `options.redactPII?: boolean | RedactOptions` — Redact PII/secrets via `redact`. `true` uses `redact`'s own defaults; pass an options object (`{ types, maskChar }`, the same shape `redact` itself takes) for finer control.
+- `options.escapeHtml?: boolean` — Escape the five HTML special characters via `escapeHtml`.
+
+**Returns:**
+
+- `string` — The sanitized text.
+
+**Example:**
+
+```js
+import { sanitize } from 'textconvert';
+
+sanitize('  Contact jordan@example.com <b>now</b>  ', {
+  trim: true,
+  redactPII: true,
+  escapeHtml: true,
+});
+// 'Contact jo**************** &lt;b&gt;now&lt;/b&gt;'
+
+sanitize('Card 4111 1111 1111 1111 and jordan@example.com', {
+  redactPII: { types: ['creditCard'] },
+});
+// 'Card ***************1111 and jordan@example.com'
+```
+
+**Edge Cases:**
+
+- Returns an error message for empty input.
+- Steps run in a **fixed order** — `trim` → `normalizeWhitespace` → `redactPII` → `escapeHtml` — regardless of the order options are given in. Redaction runs on the raw, unescaped text (so pattern matching isn't affected by HTML-escaped characters), and escaping always runs last, so the final output is safe to render no matter which other steps ran.
+- If `trim` (or `normalizeWhitespace`, which also trims) reduces whitespace-only input to an empty string, `sanitize` returns `''` directly rather than passing that empty string on to `redact`/`escapeHtml` — both of which would otherwise report it as invalid input via their own shared sentinel message, which would be a confusing thing to see back from a call that started with valid (if all-whitespace) text.
+- Every option defaults to off — `sanitize(text)` with no options returns `text` completely unchanged (aside from the shared invalid-input check on `text` itself).

--- a/src/text/redact.ts
+++ b/src/text/redact.ts
@@ -123,6 +123,13 @@ function findApiKeys(text: string): string[] {
   return candidates;
 }
 
+export interface RedactOptions {
+  /** Which types to redact. Default is 'email', 'phone', and 'creditCard'. 'apiKey' is opt-in only, given its higher false-positive risk. */
+  types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey'>;
+  /** Character(s) to use for masked positions, passed through to maskText. Default is '*'. */
+  maskChar?: string;
+}
+
 /**
  * Scans free-form text for embedded PII (emails, phone numbers, credit
  * card numbers) and secrets (API keys/tokens) and masks each match in
@@ -147,10 +154,7 @@ function findApiKeys(text: string): string[] {
  * redact('Key: AKIAIOSFODNN7EXAMPLE leaked', { types: ['apiKey'] });
  * // 'Key: ******************** leaked'
  */
-export function redact(
-  text: string,
-  options: { types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey'>; maskChar?: string } = {},
-): string {
+export function redact(text: string, options: RedactOptions = {}): string {
   if (!text) return 'Please provide a valid input text';
 
   const { types = ['email', 'phone', 'creditCard'], maskChar } = options;

--- a/src/text/sanitize.ts
+++ b/src/text/sanitize.ts
@@ -1,0 +1,68 @@
+import { escapeHtml } from './html';
+import { normalizeWhitespace } from './normalize';
+import { redact, type RedactOptions } from './redact';
+
+export interface SanitizeOptions {
+  /** Trim leading/trailing whitespace. */
+  trim?: boolean;
+  /** Collapse internal whitespace runs to a single space (also trims the ends -- see {@link normalizeWhitespace}). */
+  normalizeWhitespace?: boolean;
+  /** Redact PII/secrets via {@link redact}. `true` uses redact's own defaults; pass an options object to control its `types`/`maskChar`. */
+  redactPII?: boolean | RedactOptions;
+  /** Escape the five HTML special characters via {@link escapeHtml}. Always the last step, regardless of option order -- see below. */
+  escapeHtml?: boolean;
+}
+
+/**
+ * Runs `text` through a configurable pipeline of existing textConvert
+ * functions -- trimming, whitespace normalization, PII/secret redaction,
+ * and HTML escaping -- for the common "clean this user input/log line
+ * before it's stored or displayed" case.
+ *
+ * This is composition, not new detection logic: every step just calls
+ * the same underlying function ({@link normalizeWhitespace},
+ * {@link redact}, {@link escapeHtml}) that already exists standalone, in
+ * a fixed order regardless of the order options are given in:
+ * `trim` -> `normalizeWhitespace` -> `redactPII` -> `escapeHtml`.
+ *
+ * Redaction deliberately runs on the raw, unescaped text -- so pattern
+ * matching isn't affected by HTML-escaped characters -- and escaping
+ * always runs last, so the final output is safe to render no matter
+ * which other steps ran.
+ *
+ * @param text Text to sanitize.
+ * @param options Which steps to run. Every step defaults to off --
+ * `sanitize(text)` with no options returns `text` unchanged (aside from
+ * the shared invalid-input check).
+ * @returns The sanitized text.
+ * @example
+ * sanitize('  Contact jordan@example.com <b>now</b>  ', {
+ *   trim: true,
+ *   redactPII: true,
+ *   escapeHtml: true,
+ * });
+ * // 'Contact jo**************** &lt;b&gt;now&lt;/b&gt;'
+ */
+export function sanitize(text: string, options: SanitizeOptions = {}): string {
+  if (!text) return 'Please provide a valid input text';
+
+  let result = text;
+
+  if (options.trim) result = result.trim();
+  if (options.normalizeWhitespace) result = normalizeWhitespace(result);
+
+  // Whitespace-only input can legitimately reduce to '' at this point
+  // (e.g. sanitize('   ', { trim: true })) -- that's a valid outcome, not
+  // an error, so return it directly rather than letting an empty string
+  // flow into redact/escapeHtml, which would each report it as invalid
+  // input via their own shared sentinel message.
+  if (!result) return '';
+
+  if (options.redactPII) {
+    result = redact(result, typeof options.redactPII === 'object' ? options.redactPII : undefined);
+  }
+
+  if (options.escapeHtml) result = escapeHtml(result);
+
+  return result;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -19,8 +19,9 @@ import { maskText } from './text/mask';
 import { normalizeLineEndings, normalizeWhitespace, removeDiacritics } from './text/normalize';
 import { pluralize } from './text/pluralize';
 import { randomString } from './text/randomString';
-import { redact } from './text/redact';
+import { redact, RedactOptions } from './text/redact';
 import { reverse } from './text/reverse';
+import { sanitize, SanitizeOptions } from './text/sanitize';
 import { spread } from './text/spread';
 import { isEmail } from './text/validation/email';
 import { isPhoneNumber } from './text/validation/phoneNumber';
@@ -58,8 +59,11 @@ export {
   pluralize,
   randomString,
   redact,
+  RedactOptions,
   removeDiacritics,
   reverse,
+  sanitize,
+  SanitizeOptions,
   slugify,
   snakeCase,
   spread,

--- a/tests/Text/sanitize.test.ts
+++ b/tests/Text/sanitize.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { sanitize } from '../../src/text/sanitize';
+
+describe('#sanitize', () => {
+  it('returns text unchanged when no options are set', () => {
+    expect(sanitize('  Hello  ')).toBe('  Hello  ');
+  });
+
+  it('trims when trim is set', () => {
+    expect(sanitize('  Hello  ', { trim: true })).toBe('Hello');
+  });
+
+  it('collapses whitespace runs when normalizeWhitespace is set', () => {
+    expect(sanitize('Hello   World\n\n', { normalizeWhitespace: true })).toBe('Hello World');
+  });
+
+  it('redacts PII with redact defaults when redactPII is true', () => {
+    expect(sanitize('Contact jordan@example.com', { redactPII: true })).toBe(
+      'Contact jo****************',
+    );
+  });
+
+  it('redacts only the requested type when redactPII is an options object', () => {
+    const result = sanitize('Card 4111 1111 1111 1111 and jordan@example.com', {
+      redactPII: { types: ['creditCard'] },
+    });
+    expect(result).toBe('Card ***************1111 and jordan@example.com');
+  });
+
+  it('escapes HTML when escapeHtml is set', () => {
+    expect(sanitize('<b>hi</b>', { escapeHtml: true })).toBe('&lt;b&gt;hi&lt;/b&gt;');
+  });
+
+  it('runs steps in a fixed order regardless of option declaration order', () => {
+    const result = sanitize('  Contact jordan@example.com <b>now</b>  ', {
+      trim: true,
+      redactPII: true,
+      escapeHtml: true,
+    });
+    expect(result).toBe('Contact jo**************** &lt;b&gt;now&lt;/b&gt;');
+  });
+
+  it('combines all four steps', () => {
+    const result = sanitize('  Contact jordan@example.com <b>now</b>  ', {
+      trim: true,
+      normalizeWhitespace: true,
+      redactPII: true,
+      escapeHtml: true,
+    });
+    expect(result).toBe('Contact jo**************** &lt;b&gt;now&lt;/b&gt;');
+  });
+
+  it('returns an empty string, not the invalid-input message, when trimming empties whitespace-only input', () => {
+    expect(sanitize('   ', { trim: true })).toBe('');
+  });
+
+  it('returns the shared invalid-input message for empty input', () => {
+    expect(sanitize('')).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
Closes #365.

Adds `sanitize(text, options?)`, a single configurable entry point over `trim`/`normalizeWhitespace`/`redact`/`escapeHtml` for the common "clean this user input/log line before it's stored or displayed" case:

```ts
sanitize('  Contact jordan@example.com <b>now</b>  ', {
  trim: true,
  redactPII: true,
  escapeHtml: true,
});
// 'Contact jo**************** &lt;b&gt;now&lt;/b&gt;'
```

Resolves the two decisions the issue flagged as needing to be made deliberately rather than left to chance:

1. **`redactPII` shape**: `boolean | RedactOptions` -- `true` for `redact()`'s own defaults, or an object (`{ types, maskChar }`) for finer control, e.g. `sanitize(text, { redactPII: { types: ['creditCard'] } })`. `RedactOptions` is extracted from `redact.ts` as a named, exported interface rather than duplicated, so if #363 later extends `redact()` with new types, `sanitize()` picks that up automatically with no separate edit needed.
2. **Ordering**: fixed at `trim` → `normalizeWhitespace` → `redactPII` → `escapeHtml`, regardless of the order options are given in. Redaction runs on raw, unescaped text (so pattern matching isn't affected by HTML-escaped characters), and escaping always runs last, so the final output is safe to render no matter which other steps ran.

Also handles a real edge case: if `trim`/`normalizeWhitespace` reduces whitespace-only input to `''`, `sanitize` returns `''` directly rather than letting that empty string flow into `redact`/`escapeHtml`, which would each independently report it as invalid input via their own shared sentinel message -- confusing output for a call that started with valid (if all-whitespace) text.

This is pure composition, not new detection logic -- every step just calls the existing standalone function, so the change is low-risk to the rest of the library.