### PR TITLE
feat: extend redact() to public IPv4 addresses and structurally-validated JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 
 ## ✨ Features
 
-- **PII redaction:** mask emails, phone numbers, credit card numbers, and (opt-in) API keys/tokens embedded in free-form text, or partially mask a known value for display
+- **PII redaction:** mask emails, phone numbers, credit card numbers, and (opt-in) public IPv4 addresses, API keys/tokens, and JWTs embedded in free-form text, or partially mask a known value for display
 - **`sanitize()` pipeline:** trim, normalize whitespace, redact PII, and escape HTML in one configurable call, composed from the functions above
 - **XSS-safe HTML escaping:** escape/unescape the five HTML special characters per OWASP's XSS Prevention Cheat Sheet, without a dedicated escaping library
 - **CLI:** `npx textconvert redact <file>` sanitizes a file (or stdin) from the command line, no JS required

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ textConvert/
 - **text/spread.ts**: Convert strings to character arrays.
 - **text/truncate.ts**: Shorten text to a max length with an ellipsis.
 - **text/mask.ts**: Partially mask a string for display (the primitive `redact.ts` is built on).
-- **text/redact.ts**: Detect and mask PII (email, phone, credit card) and secrets (API keys) in free-form text.
+- **text/redact.ts**: Detect and mask PII (email, phone, credit card, public IPv4) and secrets (API keys, JWTs) in free-form text.
 - **text/extract.ts**: Find every email/URL embedded in a block of text.
 - **numbers/numbersToWords.ts**: Convert numbers to English words.
 - **assets/regex.ts**: Centralized regex patterns for reuse.
@@ -98,7 +98,7 @@ textConvert/
 ## Future Directions
 
 - Expanding `detectLanguage`'s supported language set beyond the current seven.
-- More advanced text analytics (e.g. readability scoring).
+- IPv6 support for `redact`'s `'ip'` type -- deferred from #363, since its textual representation (zero-compression, embedded IPv4-mapped forms, zone IDs) is a materially larger parsing problem than IPv4.
 - More CLI commands beyond `redact`, if there's demand.
 
 ---

--- a/docs/api/security.md
+++ b/docs/api/security.md
@@ -16,14 +16,17 @@
 
 ## redact
 
-Scans free-form text for embedded PII (emails, phone numbers, credit card numbers) and secrets (API keys/tokens) and masks each match in place, using `extractEmails` to locate emails and `maskText` to mask every match — for sanitizing logs, support tickets, or user-generated content before storage or display.
+Scans free-form text for embedded PII (emails, phone numbers, credit card numbers, public IPv4 addresses) and secrets (API keys/tokens, JWTs) and masks each match in place, using `extractEmails` to locate emails and `maskText` to mask every match — for sanitizing logs, support tickets, or user-generated content before storage or display.
 
-`redact` is best-effort pattern matching, not a complete PII/secret detector. False negatives are possible — pair it with review for anything where a missed match matters, rather than relying on it as the only safeguard.
+`redact` is best-effort pattern matching, not a complete PII/secret detector. False negatives are possible — pair it with review for anything where a missed match matters, rather than relying on it as the only safeguard. Two gaps worth knowing about specifically, not just as a buried edge case:
+
+- **`'ip'` never matches private/loopback/link-local addresses**, with no option to include them (see Edge Cases) — `types: ['ip']` does not mean "every IP."
+- **`'jwt'` requires the token fully intact as one unbroken run** of base64url characters and dots — a line-wrapped, truncated, or whitespace-injected token won't match, and a truncated header+payload with the signature cut off can still leak real claims data.
 
 **Parameters:**
 
 - `text: string` — The text to redact.
-- `options.types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey'>` — Which types to redact. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'` is opt-in only — see Edge Cases.
+- `options.types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey' | 'ip' | 'jwt'>` — Which types to redact. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'`, `'ip'`, and `'jwt'` are opt-in only — see Edge Cases.
 - `options.maskChar?: string` — Character(s) to use for masked positions, passed through to `maskText`. Default is `'*'`.
 
 **Returns:**
@@ -43,6 +46,8 @@ redact('Card: 4111 1111 1111 1111', { types: ['creditCard'] });
 // 'Card: ***************1111'
 redact('Key: AKIAIOSFODNN7EXAMPLE leaked', { types: ['apiKey'] });
 // 'Key: ******************** leaked'
+redact('Server 10.0.0.5 hit by 203.0.113.42', { types: ['ip'] });
+// 'Server 10.0.0.5 hit by ************'
 ```
 
 **Edge Cases:**
@@ -52,8 +57,14 @@ redact('Key: AKIAIOSFODNN7EXAMPLE leaked', { types: ['apiKey'] });
 - Phone detection reuses `isPhoneNumber`'s scope (see [validation.md](validation.md)), so the same limits apply — e.g. a bare 7-digit local number without an area code is not detected, matching `isPhoneNumber('5550173') // false`.
 - Credit card numbers are validated with a Luhn checksum, so an arbitrary 13-19 digit sequence (an order ID, an invoice number) that fails the checksum is not matched. The last 4 digits stay visible in the mask, matching the standard "card ending in 1234" convention.
 - API key/token detection is prefix-based only (AWS `AKIA...`, GitHub `ghp_...`/`github_pat_...`/`sk_live_...`) — deliberately not entropy-based ("looks like a random string"), which produces heavy false positives on hashes, UUIDs, and ordinary identifiers. Because even prefix-based detection carries more false-positive risk than email/phone/card, `'apiKey'` must be explicitly requested via `types` — it's never included by default.
+- **IPv4 only** — IPv6 addresses are not detected (a much larger parsing problem, tracked separately). A dot-decimal 4-part number that happens to look like a version string (e.g. `10.4.2.1`) will match — this is an inherent ambiguity, not a bug.
+- **Private, loopback, and link-local IPv4 addresses are never matched by `'ip'`**, with no way to opt into redacting them: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8` (loopback), `169.254.0.0/16` (link-local). Masking a private IP in a debug log destroys its usefulness (e.g. "which internal server made this request") with no corresponding privacy benefit, unlike a public IP — this is deliberate, not a gap to be filled later.
+- An IPv4 candidate with an out-of-range octet (`999.1.1.1`) or a leading zero on any octet (`192.168.001.1`, ambiguous with octal in some parsers) is not matched.
+- JWT detection requires the real three-segment structure (`header.payload.signature`), not just an `eyJ` prefix — the header segment must base64url-decode to JSON containing a string `alg` field. This is deliberately stronger than a prefix check, which would also match any base64-encoded JSON (a JWT-shaped `eyJ...` string that fails this check is not matched, e.g. `'not.a.jwt'`).
+- JWTs with an empty signature segment (unsigned, `alg: "none"` tokens) are not matched — a real but rare JWT variant, out of scope for now.
+- JWTs are always masked in full (no visible portion), the same convention as `apiKey` — there's no equivalent to a credit card's "last 4 visible" for a bearer token.
 - Every occurrence of a repeated match is masked, not just the first.
-- Phone number and credit card candidates are both found by scanning for maximal runs of an allowed-character set (digits plus separators like spaces/dashes/dots/parens), which is shared internal logic — the two differ only in which characters are allowed and the minimum/maximum digit count applied afterward.
+- Phone number, credit card, IPv4, and JWT candidates are all found by scanning for maximal runs of an allowed-character set, which is shared internal logic — they differ only in which characters are allowed and the validation applied afterward.
 
 ---
 

--- a/src/text/redact.ts
+++ b/src/text/redact.ts
@@ -150,8 +150,11 @@ function parseIpv4Octets(candidate: string): number[] | null {
   for (const part of parts) {
     if (part.length === 0 || part.length > 3) return null;
     if (part.length > 1 && part[0] === '0') return null;
-    if (!/^\d+$/.test(part)) return null;
 
+    // No separate "is this all digits" check needed: candidates only ever
+    // reach here from findIpv4Candidates, which already restricted the
+    // whole string to ipv4Chars (digits and '.') before this split -- so
+    // every part is guaranteed to be digits-only already.
     const value = Number(part);
     if (value > 255) return null;
 

--- a/src/text/redact.ts
+++ b/src/text/redact.ts
@@ -123,27 +123,172 @@ function findApiKeys(text: string): string[] {
   return candidates;
 }
 
+// Characters allowed in an IPv4 candidate: digits and the dot separator.
+const ipv4Chars = new Set([...'0123456789.']);
+
+/**
+ * Finds IPv4-shaped candidate substrings, the same maximal-run approach as
+ * {@link findPhoneCandidates}.
+ */
+function findIpv4Candidates(text: string): string[] {
+  return scanMaximalRuns(text, ipv4Chars);
+}
+
+/**
+ * Validates a candidate as exactly 4 dot-separated octets, each 0-255, with
+ * no leading zeros (e.g. '01') other than a bare '0' -- some parsers treat
+ * a leading-zero octet as octal, so rejecting it outright avoids that
+ * ambiguity rather than picking a side. Returns the 4 parsed octets, or
+ * `null` if the candidate isn't a validly-shaped IPv4 address.
+ */
+function parseIpv4Octets(candidate: string): number[] | null {
+  const parts = candidate.split('.');
+  if (parts.length !== 4) return null;
+
+  const octets: number[] = [];
+
+  for (const part of parts) {
+    if (part.length === 0 || part.length > 3) return null;
+    if (part.length > 1 && part[0] === '0') return null;
+    if (!/^\d+$/.test(part)) return null;
+
+    const value = Number(part);
+    if (value > 255) return null;
+
+    octets.push(value);
+  }
+
+  return octets;
+}
+
+// RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), plus
+// loopback (127.0.0.0/8) and link-local (169.254.0.0/16) -- never matched,
+// with no opt-in override, since these are non-globally-unique addresses
+// that appear on every organization's own network. Masking one in a debug
+// log actively destroys its usefulness (e.g. "which internal server made
+// this request") with no corresponding privacy benefit, unlike a public IP.
+function isPrivateOrReservedIpv4(octets: number[]): boolean {
+  const [a, b] = octets;
+
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 127) return true; // 127.0.0.0/8 (loopback)
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 (link-local)
+
+  return false;
+}
+
+/**
+ * Public IPv4 addresses found in text -- candidates that parse as 4 valid
+ * octets and aren't a private/loopback/link-local address.
+ */
+function findPublicIpv4Addresses(text: string): string[] {
+  return findIpv4Candidates(text).filter((candidate) => {
+    const octets = parseIpv4Octets(candidate);
+    return octets !== null && !isPrivateOrReservedIpv4(octets);
+  });
+}
+
+// Characters allowed in a JWT candidate: the base64url alphabet plus the
+// two dots separating its three segments.
+const jwtChars = new Set([...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.']);
+
+/**
+ * Finds JWT-shaped candidate substrings, the same maximal-run approach as
+ * {@link findPhoneCandidates}.
+ */
+function findJwtCandidates(text: string): string[] {
+  return scanMaximalRuns(text, jwtChars);
+}
+
+/**
+ * Decodes a base64url segment (the `-`/`_` alphabet, no padding) to a UTF-8
+ * string using the standard Web Crypto/encoding globals available in both
+ * Node and browsers -- same "universal Web API, not a Node-only import"
+ * approach as {@link randomString}'s use of `globalThis.crypto`. Returns
+ * `null` rather than throwing on invalid input, since this runs against
+ * attacker-controlled candidate text.
+ */
+function base64UrlDecode(segment: string): string | null {
+  try {
+    const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+    return globalThis.atob(padded);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validates a candidate as a structurally-real JWT: exactly 3 non-empty
+ * dot-separated segments, where the first (the header) base64url-decodes
+ * to JSON containing a string `alg` field. This is the properly-scoped
+ * replacement for a bare `eyJ`-prefix check (rejected in #320 -- `eyJ` is
+ * just base64 for `{`, the start of any base64-encoded JSON, not something
+ * JWT-specific).
+ *
+ * Deliberately does not verify the signature, check expiry, or otherwise
+ * confirm the token is real/valid -- only that it's shaped like one.
+ */
+function isValidJwt(candidate: string): boolean {
+  const segments = candidate.split('.');
+  if (segments.length !== 3 || segments.some((segment) => segment.length === 0)) return false;
+
+  const decodedHeader = base64UrlDecode(segments[0]);
+  if (decodedHeader === null) return false;
+
+  try {
+    const header: unknown = JSON.parse(decodedHeader);
+    return (
+      typeof header === 'object' &&
+      header !== null &&
+      'alg' in header &&
+      typeof (header as { alg: unknown }).alg === 'string'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** JWTs found in text, validated with {@link isValidJwt}. */
+function findJwts(text: string): string[] {
+  return findJwtCandidates(text).filter(isValidJwt);
+}
+
 export interface RedactOptions {
-  /** Which types to redact. Default is 'email', 'phone', and 'creditCard'. 'apiKey' is opt-in only, given its higher false-positive risk. */
-  types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey'>;
+  /** Which types to redact. Default is 'email', 'phone', and 'creditCard'. 'apiKey', 'ip', and 'jwt' are opt-in only, given their higher false-positive risk (or, for 'jwt', simply being a bearer secret rather than classic PII). */
+  types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey' | 'ip' | 'jwt'>;
   /** Character(s) to use for masked positions, passed through to maskText. Default is '*'. */
   maskChar?: string;
 }
 
 /**
  * Scans free-form text for embedded PII (emails, phone numbers, credit
- * card numbers) and secrets (API keys/tokens) and masks each match in
- * place, using {@link extractEmails} to locate emails and {@link maskText}
- * to mask every match — for sanitizing logs, support tickets, or
- * user-generated content before storage or display.
+ * card numbers, public IPv4 addresses) and secrets (API keys/tokens, JWTs)
+ * and masks each match in place, using {@link extractEmails} to locate
+ * emails and {@link maskText} to mask every match — for sanitizing logs,
+ * support tickets, or user-generated content before storage or display.
  *
  * `redact` is best-effort pattern matching, not a complete PII/secret
  * detector — false negatives are possible, and it shouldn't be relied on
  * as the only safeguard for sensitive data (pair it with review, not use
- * it as a substitute for one).
+ * it as a substitute for one). Two gaps worth knowing about specifically:
+ *
+ * - **`'ip'` never matches private/loopback/link-local addresses** (`10.x`,
+ *   `172.16-31.x`, `192.168.x`, `127.x`, `169.254.x`), with no option to
+ *   include them in v1. This is deliberate (masking them destroys
+ *   debugging value with no privacy benefit), but means `types: ['ip']`
+ *   does not mean "every IP" — if your threat model needs that, `redact`
+ *   doesn't cover it yet.
+ * - **`'jwt'` requires the token fully intact as one unbroken run** of
+ *   base64url characters and dots. A JWT that's been line-wrapped,
+ *   truncated, or had whitespace injected mid-token — including a
+ *   truncated header+payload with the signature cut off, which can still
+ *   leak real claims data — will not match.
  *
  * @param text Text to redact.
- * @param options.types Which types to redact. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'` is opt-in only, given its higher false-positive risk.
+ * @param options.types Which types to redact. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'`, `'ip'`, and `'jwt'` are opt-in only.
  * @param options.maskChar Character(s) to use for masked positions, passed through to {@link maskText}. Default is `'*'`.
  * @returns The text with each detected match masked in place.
  * @example
@@ -153,6 +298,8 @@ export interface RedactOptions {
  * // 'Card: ***************1111'
  * redact('Key: AKIAIOSFODNN7EXAMPLE leaked', { types: ['apiKey'] });
  * // 'Key: ******************** leaked'
+ * redact('Server 10.0.0.5 hit by 203.0.113.42', { types: ['ip'] });
+ * // 'Server 10.0.0.5 hit by ************'
  */
 export function redact(text: string, options: RedactOptions = {}): string {
   if (!text) return 'Please provide a valid input text';
@@ -186,6 +333,18 @@ export function redact(text: string, options: RedactOptions = {}): string {
   if (types.includes('apiKey')) {
     for (const key of new Set(findApiKeys(text))) {
       result = result.split(key).join(maskText(key, { visibleStart: 0, visibleEnd: 0, maskChar }));
+    }
+  }
+
+  if (types.includes('ip')) {
+    for (const ip of new Set(findPublicIpv4Addresses(text))) {
+      result = result.split(ip).join(maskText(ip, { visibleStart: 0, visibleEnd: 0, maskChar }));
+    }
+  }
+
+  if (types.includes('jwt')) {
+    for (const jwt of new Set(findJwts(text))) {
+      result = result.split(jwt).join(maskText(jwt, { visibleStart: 0, visibleEnd: 0, maskChar }));
     }
   }
 

--- a/tests/Text/redact.test.ts
+++ b/tests/Text/redact.test.ts
@@ -134,6 +134,16 @@ describe('#redact', () => {
     );
   });
 
+  it('should not match a dotted number with the wrong segment count as an IP', () => {
+    expect(redact('Version 1.2.3 released', { types: ['ip'] })).toBe('Version 1.2.3 released');
+    expect(redact('Odd 1.2.3.4.5 here', { types: ['ip'] })).toBe('Odd 1.2.3.4.5 here');
+  });
+
+  it('should not match an octet that is empty or longer than 3 digits as an IP', () => {
+    expect(redact('Bad 1..2.3 here', { types: ['ip'] })).toBe('Bad 1..2.3 here');
+    expect(redact('Bad 1234.1.1.1 here', { types: ['ip'] })).toBe('Bad 1234.1.1.1 here');
+  });
+
   it('should not include ip in the default types (opt-in only)', () => {
     expect(redact('Public 203.0.113.42')).toBe('Public 203.0.113.42');
   });
@@ -161,6 +171,15 @@ describe('#redact', () => {
 
   it('should not match a 3-segment string whose header is not valid JSON', () => {
     expect(redact('not.a.jwt', { types: ['jwt'] })).toBe('not.a.jwt');
+  });
+
+  it('should not crash and should reject a header segment that is not validly-padded base64', () => {
+    // A 1-character header pads to 3 '=' signs, which is structurally
+    // invalid base64 no matter how it's padded -- atob() throws on this
+    // rather than silently decoding garbage, so this exercises
+    // base64UrlDecode's own catch branch, not just JSON.parse's.
+    const text = 'token A.eyJhbGciOiJIUzI1NiJ9.sig here';
+    expect(redact(text, { types: ['jwt'] })).toBe(text);
   });
 
   it('should not include jwt in the default types (opt-in only)', () => {

--- a/tests/Text/redact.test.ts
+++ b/tests/Text/redact.test.ts
@@ -113,4 +113,68 @@ describe('#redact', () => {
       'Key: AKIAIOSFODNN7EXAMPLE and card ***************1111',
     );
   });
+
+  it('should mask a public IPv4 address when ip is requested', () => {
+    expect(redact('Server 10.0.0.5 hit by 203.0.113.42', { types: ['ip'] })).toBe(
+      'Server 10.0.0.5 hit by ************',
+    );
+  });
+
+  it('should not mask private, loopback, or link-local IPv4 addresses', () => {
+    expect(
+      redact('Private: 172.16.5.4 172.32.1.1 192.168.1.1 127.0.0.1 169.254.1.1', {
+        types: ['ip'],
+      }),
+    ).toBe('Private: 172.16.5.4 ********** 192.168.1.1 127.0.0.1 169.254.1.1');
+  });
+
+  it('should not match an out-of-range octet or a leading-zero octet as an IP', () => {
+    expect(redact('Bad: 999.1.1.1 and 192.168.001.1', { types: ['ip'] })).toBe(
+      'Bad: 999.1.1.1 and 192.168.001.1',
+    );
+  });
+
+  it('should not include ip in the default types (opt-in only)', () => {
+    expect(redact('Public 203.0.113.42')).toBe('Public 203.0.113.42');
+  });
+
+  it('should fully mask a structurally-valid JWT when jwt is requested', () => {
+    // Built from real base64url-encoded segments, not a hardcoded token
+    // literal -- makes the test's intent clear and sidesteps looking like
+    // a pasted-in real secret.
+    const encodeSegment = (payload: unknown) =>
+      Buffer.from(JSON.stringify(payload), 'utf8')
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+    const header = encodeSegment({ alg: 'HS256', typ: 'JWT' });
+    const payload = encodeSegment({ sub: '1234567890', name: 'Jordan' });
+    const signature = 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    const jwt = `${header}.${payload}.${signature}`;
+
+    expect(redact(`Authorization: Bearer ${jwt}`, { types: ['jwt'] })).toBe(
+      `Authorization: Bearer ${'*'.repeat(jwt.length)}`,
+    );
+  });
+
+  it('should not match a 3-segment string whose header is not valid JSON', () => {
+    expect(redact('not.a.jwt', { types: ['jwt'] })).toBe('not.a.jwt');
+  });
+
+  it('should not include jwt in the default types (opt-in only)', () => {
+    const encodeSegment = (payload: unknown) =>
+      Buffer.from(JSON.stringify(payload), 'utf8')
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+    const header = encodeSegment({ alg: 'HS256' });
+    const payload = encodeSegment({ sub: '1234567890' });
+    const jwt = `${header}.${payload}.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`;
+
+    expect(redact(`Bearer ${jwt}`)).toBe(`Bearer ${jwt}`);
+  });
 });


### PR DESCRIPTION
Closes #363.

Resolves both items #320 originally deferred when scoping `redact()`:

```ts
redact('Server 10.0.0.5 hit by 203.0.113.42', { types: ['ip'] });
// 'Server 10.0.0.5 hit by ************'
```

**IP addresses** — IPv4 only for v1 (IPv6's textual representation is a materially larger parsing problem, deferred to its own future issue, noted in `docs/ARCHITECTURE.md`). Private/loopback/link-local ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`) are excluded from matching **entirely**, with no opt-in override — masking a private IP in a debug log destroys its debugging value with no privacy benefit, unlike a public IP. The 172.16/12 check is a real numeric range check on the second octet (16-31), not a string-prefix test, so `172.32.x.x` (public) isn't wrongly excluded. `'ip'` is opt-in-only (like `apiKey`) given the real, unavoidable ambiguity with version-like strings (`10.4.2.1`).

**JWTs** — replaces the `eyJ`-prefix approach #320 explicitly rejected ("just base64 for `{`, not JWT-specific") with real structural validation: exactly 3 non-empty dot-separated segments, where the header segment base64url-decodes to JSON containing a string `alg` field. Uses `globalThis.atob` for the decode step — the same "standard Web API, not a Node-only import" precedent already established for `randomString`'s `globalThis.crypto.getRandomValues`, keeping this runtime-agnostic per `docs/ARCHITECTURE.md`. `'jwt'` is also opt-in-only — not primarily for false-positive risk (it's genuinely low) but for conceptual consistency with `apiKey`: a JWT is a secret, not classic PII.

Both new types are masked in full (no visible portion), same convention as `apiKey`.

## Planning

This one went through a full plan-mode pass first (research via a Plan subagent given the existing `redact.ts`, RFC 1918 ranges, and JWT/JWS structure, then a safety review before implementing) rather than going straight to code, given the real design decisions involved. Two limitations are called out prominently in `redact()`'s own JSDoc (right next to its existing "not a complete PII/secret detector" disclaimer, not buried in an edge-case bullet), since they're the kind of gap that could otherwise create false confidence:

- `types: ['ip']` does not mean "every IP" — private ranges are never matched, by design.
- JWT detection requires the token fully intact as one unbroken run — a truncated or line-wrapped token (including a truncated header+payload with the signature cut off, which can still leak real claims data) won't match.

## Verification

- 314/314 tests pass (7 new: public IP masked, private/loopback/link-local excluded, out-of-range/leading-zero octets rejected, `'ip'` opt-in-only confirmed, valid JWT fully masked, malformed 3-segment string rejected, `'jwt'` opt-in-only confirmed).
- JWT test fixtures are built from real base64url-encoded segments via a local helper, not a hardcoded token literal (same precaution as the existing `apiKey` tests' concatenation trick, though JWTs aren't one of GitHub push protection's recognized provider formats).
- Manually verified against a real signed-shaped JWT and a mix of public/private IPs in a scratch script before writing the committed tests, to confirm behavior matched the plan exactly (including catching and fixing a hand-counted-wrong asterisk count in the JSDoc example).