### PR TITLE
feat: add ordinal function for number suffix form

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Text utilities: truncate with word-boundary awareness
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
+- Ordinal suffixes: turns `21` into `'21st'`
 - Generation: cryptographically secure random strings for IDs, tokens, or test fixtures
 - Grammar: pluralize English words for UI copy like "1 item" / "5 items"
 - Normalization: strip diacritics, collapse whitespace, and normalize line endings
@@ -146,6 +147,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `wordFrequency(text)`                        | Count how many times each word appears                             |
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                             |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words                |
+| `ordinal(number)`                            | Get a number's ordinal suffix form (`21` -> `'21st'`)              |
 | `randomString(length, options?)`             | Generate a cryptographically secure random string                  |
 | `pluralize(word, count?)`                    | Return the plural form of an English word                          |
 | `removeDiacritics(text)`                     | Strip accents from accented characters                             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml), [sanitize](#sanitize)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate), [wordFrequency](#wordfrequency)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
-- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords)
+- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal)
 - [**Generation**](api/generation.md) — [randomString](#randomstring)
 - [**Grammar**](api/grammar.md) — [pluralize](#pluralize)
 - [**Normalization**](api/normalization.md) — [removeDiacritics](#removediacritics), [normalizeWhitespace](#normalizewhitespace), [normalizeLineEndings](#normalizelineendings)
@@ -164,6 +164,10 @@ Full docs: [docs/api/language.md#detectlanguage](api/language.md#detectlanguage)
 ### numbersToWords
 
 Full docs: [docs/api/numbers.md#numberstowords](api/numbers.md#numberstowords)
+
+### ordinal
+
+Full docs: [docs/api/numbers.md#ordinal](api/numbers.md#ordinal)
 
 ---
 

--- a/docs/api/numbers.md
+++ b/docs/api/numbers.md
@@ -1,6 +1,6 @@
 # Numbers
 
-`numbersToWords`.
+`numbersToWords`, `ordinal`.
 
 ---
 
@@ -29,4 +29,38 @@ numbersToWords(-5); // 'Please provide a valid number under 100 million'
 **Edge Cases:**
 
 - Returns `'Please provide a valid number under 100 million'` — rather than throwing — for numbers `>= 100,000,000`, negative numbers, and non-integers, matching the sentinel-return convention every other function in this library follows.
+- English only — there's no locale/language parameter.
+
+---
+
+## ordinal
+
+Gets a non-negative integer's ordinal suffix form.
+
+**Parameters:**
+
+- `number: number` — The number to convert.
+
+**Returns:**
+
+- `string` — The number followed by its ordinal suffix, or an error message for invalid input.
+
+**Example:**
+
+```js
+import { ordinal } from 'textconvert';
+
+ordinal(1); // '1st'
+ordinal(2); // '2nd'
+ordinal(3); // '3rd'
+ordinal(4); // '4th'
+ordinal(11); // '11th' -- not '11st'
+ordinal(21); // '21st'
+ordinal(112); // '112th' -- not '112nd'
+```
+
+**Edge Cases:**
+
+- English ordinals go by the last **two** digits, not just the last one — `11`, `12`, and `13` are always `'th'`, even though their last digit alone (`1`, `2`, `3`) would otherwise map to `'st'`/`'nd'`/`'rd'`. This repeats every hundred (`111`, `112`, `113` are `'th'` too, but `121` is back to `'st'`).
+- Returns `'Please provide a valid input text'` — rather than throwing — for negative numbers, non-integers, and `NaN`.
 - English only — there's no locale/language parameter.

--- a/src/numbers/ordinal.ts
+++ b/src/numbers/ordinal.ts
@@ -1,0 +1,27 @@
+/**
+ * Get a non-negative integer's ordinal suffix form (e.g. `1` -> `'1st'`).
+ * @param number Non-negative integer to convert.
+ * @returns The number followed by its ordinal suffix, or the shared invalid-input message for anything else.
+ * @example
+ * ordinal(1); // '1st'
+ * ordinal(11); // '11th'
+ * ordinal(21); // '21st'
+ */
+export function ordinal(number: number): string {
+  if (!Number.isInteger(number) || number < 0) {
+    return 'Please provide a valid input text';
+  }
+
+  // English ordinals go by the last *two* digits, not just the last one --
+  // 11/12/13 are always 'th' even though their last digit (1/2/3) would
+  // otherwise map to 'st'/'nd'/'rd'.
+  const lastTwoDigits = number % 100;
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) {
+    return `${number}th`;
+  }
+
+  const lastDigit = number % 10;
+  const suffix = lastDigit === 1 ? 'st' : lastDigit === 2 ? 'nd' : lastDigit === 3 ? 'rd' : 'th';
+
+  return `${number}${suffix}`;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -27,6 +27,7 @@ import { isEmail } from './text/validation/email';
 import { isPhoneNumber } from './text/validation/phoneNumber';
 import { isUrl } from './text/validation/url';
 import { numbersToWords } from './numbers/numbersToWords';
+import { ordinal } from './numbers/ordinal';
 import { slugify } from './text/slugify';
 import { truncate } from './text/truncate';
 
@@ -55,6 +56,7 @@ export {
   normalizeLineEndings,
   normalizeWhitespace,
   numbersToWords,
+  ordinal,
   pascalCase,
   pluralize,
   randomString,

--- a/tests/Numbers/ordinal.test.ts
+++ b/tests/Numbers/ordinal.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { ordinal } from '../../src/textConvert';
+
+describe('#ordinal', () => {
+  it('should append st/nd/rd/th based on the last digit', () => {
+    expect(ordinal(1)).toBe('1st');
+    expect(ordinal(2)).toBe('2nd');
+    expect(ordinal(3)).toBe('3rd');
+    expect(ordinal(4)).toBe('4th');
+    expect(ordinal(0)).toBe('0th');
+  });
+
+  it('should use th for the 11/12/13 exception regardless of the last digit', () => {
+    expect(ordinal(11)).toBe('11th');
+    expect(ordinal(12)).toBe('12th');
+    expect(ordinal(13)).toBe('13th');
+  });
+
+  it('should resume st/nd/rd for 21-23 despite 11-13 ending the previous ten', () => {
+    expect(ordinal(21)).toBe('21st');
+    expect(ordinal(22)).toBe('22nd');
+    expect(ordinal(23)).toBe('23rd');
+  });
+
+  it('should reapply the 11/12/13 exception for every hundred (111, 112, 113)', () => {
+    expect(ordinal(111)).toBe('111th');
+    expect(ordinal(112)).toBe('112th');
+    expect(ordinal(113)).toBe('113th');
+    expect(ordinal(121)).toBe('121st');
+  });
+
+  it('should handle large numbers', () => {
+    expect(ordinal(1001)).toBe('1001st');
+  });
+
+  it("should return 'Please provide a valid input text' for negative numbers", () => {
+    expect(ordinal(-1)).toBe('Please provide a valid input text');
+  });
+
+  it("should return 'Please provide a valid input text' for non-integers", () => {
+    expect(ordinal(1.5)).toBe('Please provide a valid input text');
+  });
+
+  it("should return 'Please provide a valid input text' for NaN", () => {
+    expect(ordinal(NaN)).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `ordinal(number): string`, returning a non-negative integer's ordinal suffix form (`21` -> `'21st'`), handling the 11th/12th/13th exception correctly across every hundred.
- Uses the shared invalid-input sentinel for negative numbers, non-integers, and `NaN`, per the issue's scoping.

Closes #384.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (325 tests passing, including 8 new `ordinal` cases)
- [x] `npm run format:check`