### PR TITLE
feat: add ordinalToWords function for ordinal word form

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Language detection: English, French, Spanish, German, Italian, Portuguese, Dutch
 - Number to words: Converts numbers < 100 million to English words
 - Ordinal suffixes: turns `21` into `'21st'`
+- Ordinal words: turns `21` into `'twenty-first'`
 - Generation: cryptographically secure random strings for IDs, tokens, or test fixtures
 - Grammar: pluralize English words for UI copy like "1 item" / "5 items"
 - Normalization: strip diacritics, collapse whitespace, and normalize line endings
@@ -148,6 +149,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                             |
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words                |
 | `ordinal(number)`                            | Get a number's ordinal suffix form (`21` -> `'21st'`)              |
+| `ordinalToWords(number)`                     | Get a number's ordinal word form (`21` -> `'twenty-first'`)        |
 | `randomString(length, options?)`             | Generate a cryptographically secure random string                  |
 | `pluralize(word, count?)`                    | Return the plural form of an English word                          |
 | `removeDiacritics(text)`                     | Strip accents from accented characters                             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml), [sanitize](#sanitize)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate), [wordFrequency](#wordfrequency)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
-- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal)
+- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal), [ordinalToWords](#ordinaltowords)
 - [**Generation**](api/generation.md) — [randomString](#randomstring)
 - [**Grammar**](api/grammar.md) — [pluralize](#pluralize)
 - [**Normalization**](api/normalization.md) — [removeDiacritics](#removediacritics), [normalizeWhitespace](#normalizewhitespace), [normalizeLineEndings](#normalizelineendings)
@@ -168,6 +168,10 @@ Full docs: [docs/api/numbers.md#numberstowords](api/numbers.md#numberstowords)
 ### ordinal
 
 Full docs: [docs/api/numbers.md#ordinal](api/numbers.md#ordinal)
+
+### ordinalToWords
+
+Full docs: [docs/api/numbers.md#ordinaltowords](api/numbers.md#ordinaltowords)
 
 ---
 

--- a/docs/api/numbers.md
+++ b/docs/api/numbers.md
@@ -1,6 +1,6 @@
 # Numbers
 
-`numbersToWords`, `ordinal`.
+`numbersToWords`, `ordinal`, `ordinalToWords`.
 
 ---
 
@@ -63,4 +63,36 @@ ordinal(112); // '112th' -- not '112nd'
 
 - English ordinals go by the last **two** digits, not just the last one — `11`, `12`, and `13` are always `'th'`, even though their last digit alone (`1`, `2`, `3`) would otherwise map to `'st'`/`'nd'`/`'rd'`. This repeats every hundred (`111`, `112`, `113` are `'th'` too, but `121` is back to `'st'`).
 - Returns `'Please provide a valid input text'` — rather than throwing — for negative numbers, non-integers, and `NaN`.
+- English only — there's no locale/language parameter.
+
+---
+
+## ordinalToWords
+
+Gets a non-negative integer's ordinal word form, building on `numbersToWords`.
+
+**Parameters:**
+
+- `number: number` — The number to convert.
+
+**Returns:**
+
+- `string` — The number's ordinal words, or an error message for invalid input.
+
+**Example:**
+
+```js
+import { ordinalToWords } from 'textconvert';
+
+ordinalToWords(1); // 'first'
+ordinalToWords(3); // 'third'
+ordinalToWords(21); // 'twenty-first'
+ordinalToWords(100); // 'one hundredth'
+```
+
+**Edge Cases:**
+
+- Only the **last word** of `numbersToWords`'s cardinal output changes to its ordinal form — the rest of a compound number stays exactly as `numbersToWords` produced it (`145` -> `'one hundred and forty-fifth'`, not `'one hundred and forty-threeth'` or similar).
+- Irregular endings: `one` -> `first`, `two` -> `second`, `three` -> `third`, `five` -> `fifth`, `eight` -> `eighth`, `nine` -> `ninth`, `twelve` -> `twelfth`. Tens ending in `-y` (`twenty`, `thirty`, ...) become `-ieth` (`twentieth`, `thirtieth`). Everything else just appends `-th` (`four` -> `fourth`, `thousand` -> `thousandth`).
+- Returns `'Please provide a valid number under 100 million'` — rather than throwing — for numbers `>= 100,000,000`, negative numbers, and non-integers, matching `numbersToWords`'s own convention.
 - English only — there's no locale/language parameter.

--- a/src/numbers/numbersToWords.ts
+++ b/src/numbers/numbersToWords.ts
@@ -5,6 +5,16 @@ const numbers: string[] =
   );
 const tens: string[] = 'twenty thirty forty fifty sixty seventy eighty ninety'.split(' ');
 
+// Shared with ordinalToWords, which builds on numbersToWords's cardinal
+// output and needs to reject the same inputs the same way.
+const MAX_WORDABLE_NUMBER = 100000000;
+
+export function isValidWordableNumber(number: number): boolean {
+  return Number.isInteger(number) && number >= 0 && number < MAX_WORDABLE_NUMBER;
+}
+
+export const INVALID_NUMBER_MESSAGE = 'Please provide a valid number under 100 million';
+
 /**
  * Get any non-negative integer below 100 million converted to words.
  * @param number Integer input to turn into text.
@@ -17,8 +27,8 @@ export function numbersToWords(number: number): string {
   // Reject anything that isn't a non-negative integer under 100 million,
   // matching the sentinel-return convention every other function in this
   // library follows rather than throwing.
-  if (!Number.isInteger(number) || number < 0 || number >= 100000000) {
-    return 'Please provide a valid number under 100 million';
+  if (!isValidWordableNumber(number)) {
+    return INVALID_NUMBER_MESSAGE;
   }
 
   // Check if the input is between 0-19

--- a/src/numbers/ordinalToWords.ts
+++ b/src/numbers/ordinalToWords.ts
@@ -1,0 +1,54 @@
+import { INVALID_NUMBER_MESSAGE, isValidWordableNumber, numbersToWords } from './numbersToWords';
+
+// Irregular ordinal endings that don't follow the plain "+th" rule.
+const irregularOrdinals: Record<string, string> = {
+  one: 'first',
+  two: 'second',
+  three: 'third',
+  five: 'fifth',
+  eight: 'eighth',
+  nine: 'ninth',
+  twelve: 'twelfth',
+};
+
+function ordinalizeWord(word: string): string {
+  if (word in irregularOrdinals) return irregularOrdinals[word];
+  // Tens ending in "-y" (twenty, thirty, ...) drop the "y" for "-ieth".
+  if (word.endsWith('y')) return `${word.slice(0, -1)}ieth`;
+  return `${word}th`;
+}
+
+/**
+ * Get a non-negative integer's ordinal word form (e.g. `21` -> `'twenty-first'`).
+ * @param number Non-negative integer to convert.
+ * @returns The number's ordinal words, or an error message for invalid input.
+ * @example
+ * ordinalToWords(1); // 'first'
+ * ordinalToWords(21); // 'twenty-first'
+ * ordinalToWords(100); // 'one hundredth'
+ */
+export function ordinalToWords(number: number): string {
+  if (!isValidWordableNumber(number)) {
+    return INVALID_NUMBER_MESSAGE;
+  }
+
+  const cardinal = numbersToWords(number);
+
+  // Only the last word/segment of the cardinal form changes to its ordinal
+  // form -- everything before it stays exactly as numbersToWords produced it.
+  const lastSpaceIndex = cardinal.lastIndexOf(' ');
+  const prefix = lastSpaceIndex === -1 ? '' : cardinal.slice(0, lastSpaceIndex + 1);
+  const lastSegment = lastSpaceIndex === -1 ? cardinal : cardinal.slice(lastSpaceIndex + 1);
+
+  // A hyphenated segment (e.g. "forty-five") is a tens-ones compound --
+  // only its ones word takes the ordinal form ("forty-fifth", not
+  // "fortieth-five").
+  const hyphenIndex = lastSegment.lastIndexOf('-');
+  if (hyphenIndex === -1) {
+    return prefix + ordinalizeWord(lastSegment);
+  }
+
+  const tensPart = lastSegment.slice(0, hyphenIndex + 1);
+  const onesPart = lastSegment.slice(hyphenIndex + 1);
+  return prefix + tensPart + ordinalizeWord(onesPart);
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -28,6 +28,7 @@ import { isPhoneNumber } from './text/validation/phoneNumber';
 import { isUrl } from './text/validation/url';
 import { numbersToWords } from './numbers/numbersToWords';
 import { ordinal } from './numbers/ordinal';
+import { ordinalToWords } from './numbers/ordinalToWords';
 import { slugify } from './text/slugify';
 import { truncate } from './text/truncate';
 
@@ -57,6 +58,7 @@ export {
   normalizeWhitespace,
   numbersToWords,
   ordinal,
+  ordinalToWords,
   pascalCase,
   pluralize,
   randomString,

--- a/tests/Numbers/ordinalToWords.test.ts
+++ b/tests/Numbers/ordinalToWords.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { ordinalToWords } from '../../src/textConvert';
+
+describe('#ordinalToWords', () => {
+  it('should convert single-digit numbers using the irregular table', () => {
+    expect(ordinalToWords(1)).toBe('first');
+    expect(ordinalToWords(2)).toBe('second');
+    expect(ordinalToWords(3)).toBe('third');
+    expect(ordinalToWords(5)).toBe('fifth');
+    expect(ordinalToWords(8)).toBe('eighth');
+    expect(ordinalToWords(9)).toBe('ninth');
+    expect(ordinalToWords(12)).toBe('twelfth');
+  });
+
+  it('should apply the generic +th rule for regular numbers', () => {
+    expect(ordinalToWords(0)).toBe('zeroth');
+    expect(ordinalToWords(4)).toBe('fourth');
+    expect(ordinalToWords(6)).toBe('sixth');
+    expect(ordinalToWords(7)).toBe('seventh');
+    expect(ordinalToWords(10)).toBe('tenth');
+    expect(ordinalToWords(11)).toBe('eleventh');
+    expect(ordinalToWords(13)).toBe('thirteenth');
+    expect(ordinalToWords(19)).toBe('nineteenth');
+  });
+
+  it('should convert whole tens using the -y -> -ieth rule', () => {
+    expect(ordinalToWords(20)).toBe('twentieth');
+    expect(ordinalToWords(30)).toBe('thirtieth');
+    expect(ordinalToWords(40)).toBe('fortieth');
+    expect(ordinalToWords(90)).toBe('ninetieth');
+  });
+
+  it('should only ordinalize the ones word in a tens-ones compound', () => {
+    expect(ordinalToWords(21)).toBe('twenty-first');
+    expect(ordinalToWords(32)).toBe('thirty-second');
+    expect(ordinalToWords(45)).toBe('forty-fifth');
+    expect(ordinalToWords(89)).toBe('eighty-ninth');
+    expect(ordinalToWords(99)).toBe('ninety-ninth');
+  });
+
+  it('should ordinalize only the final segment of a compound number', () => {
+    expect(ordinalToWords(100)).toBe('one hundredth');
+    expect(ordinalToWords(101)).toBe('one hundred and first');
+    expect(ordinalToWords(145)).toBe('one hundred and forty-fifth');
+    expect(ordinalToWords(1000)).toBe('one thousandth');
+    expect(ordinalToWords(1001)).toBe('one thousand first');
+    expect(ordinalToWords(12345)).toBe('twelve thousand three hundred and forty-fifth');
+    expect(ordinalToWords(100000)).toBe('one hundred thousandth');
+    expect(ordinalToWords(1000000)).toBe('one millionth');
+  });
+
+  it("should return 'Please provide a valid number under 100 million' for negative numbers", () => {
+    expect(ordinalToWords(-1)).toBe('Please provide a valid number under 100 million');
+  });
+
+  it("should return 'Please provide a valid number under 100 million' for non-integers", () => {
+    expect(ordinalToWords(1.5)).toBe('Please provide a valid number under 100 million');
+  });
+
+  it("should return 'Please provide a valid number under 100 million' for numbers >= 100 million", () => {
+    expect(ordinalToWords(100000000)).toBe('Please provide a valid number under 100 million');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `ordinalToWords(number): string`, converting `numbersToWords`'s cardinal output to ordinal word form (`21` -> `'twenty-first'`) by ordinalizing only the last word/segment and leaving the rest of a compound number untouched.
- Handles the irregular endings (`one`->`first`, `two`->`second`, `three`->`third`, `five`->`fifth`, `eight`->`eighth`, `nine`->`ninth`, `twelve`->`twelfth`), the `-y`->`-ieth` tens rule, and the generic `+th` fallback.
- Extracts a small shared `isValidWordableNumber`/`INVALID_NUMBER_MESSAGE` from `numbersToWords.ts` so both functions validate and error identically, instead of duplicating the range check.

Closes #385.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (333 tests passing, including 8 new `ordinalToWords` cases)
- [x] `npm run format:check`