### PR TITLE
chore: add manual next dist-tag publish workflow

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,48 @@
+name: publish-next
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-next:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org/'
+      - name: Install dependencies
+        run: npm ci || npm install
+      - name: Update npm for OIDC trusted publishing support
+        run: npm install -g npm@latest
+      - name: Compute a throwaway prerelease version
+        id: version
+        run: |
+          CURRENT_MAJOR=$(node -p "require('./package.json').version.split('.')[0]")
+          NEXT_MAJOR=$((CURRENT_MAJOR + 1))
+          VERSION="${NEXT_MAJOR}.0.0-next.${{ github.run_number }}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Set the throwaway version
+        # Local to this checkout only -- never committed or pushed, so it
+        # can't interfere with release-please's own version manifest on
+        # main. Whatever's currently on main (however much of the v3.0.0
+        # batch has landed at the time this is triggered) gets published
+        # under this one-off version instead.
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+      - name: Build
+        run: npm run build
+      - name: Publish to npm under the next tag
+        run: npm publish --tag next --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Summary
+        run: |
+          echo "Published \`textconvert@${{ steps.version.outputs.version }}\` under the \`next\` tag." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Try it with: \`npm install textconvert@next\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-only GitHub Actions workflow (`.github/workflows/publish-next.yml`) that publishes whatever's currently on `main` to npm under the `next` dist-tag, as a throwaway `<nextMajor>.0.0-next.<run number>` version.
- Never touches `package.json`, `.release-please-manifest.json`, or `CHANGELOG.md` on `main` -- the version bump happens only inside the CI checkout, right before publish, and nothing is committed or pushed back.
- Only runs when manually triggered from the Actions tab, never on push, so it can't accidentally publish.
- Lets early adopters try `npm install textconvert@next` to test the in-progress v3.0.0 breaking changes before the batch is finished and released as `latest`.

Closes #396.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run format:check`
- [ ] Manually trigger the workflow once to confirm it actually publishes correctly (can't be verified by CI alone, since it needs `workflow_dispatch` + real npm credentials)