### PR TITLE
feat: add scan() to expose redact()'s detection as structured matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Thumbs.db
 tasks.md
 *.private.md
 *.todo.md
+
+.vexp/
+.claude

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 ## ✨ Features
 
 - **PII redaction:** mask emails, phone numbers, credit card numbers, and (opt-in) public IPv4 addresses, API keys/tokens, and JWTs embedded in free-form text, or partially mask a known value for display
+- **`scan()`:** the same PII/secret detection as `redact()`, returned as structured `{ type, value, start, end }` matches instead of masked in place
 - **`sanitize()` pipeline:** trim, normalize whitespace, redact PII, and escape HTML in one configurable call, composed from the functions above
 - **XSS-safe HTML escaping:** escape/unescape the five HTML special characters per OWASP's XSS Prevention Cheat Sheet, without a dedicated escaping library
 - **CLI:** `npx textconvert redact <file>` sanitizes a file (or stdin) from the command line, no JS required
@@ -143,6 +144,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis                     |
 | `maskText(text, options?)`                   | Partially mask a string for display                                |
 | `redact(text, options?)`                     | Mask PII/secrets embedded in text                                  |
+| `scan(text, options?)`                       | Find PII/secrets embedded in text as structured matches            |
 | `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time, readability) |
 | `isPalindrome(text)`                         | Check if text is a palindrome                                      |
 | `wordFrequency(text)`                        | Count how many times each word appears                             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Case Conversion**](api/case-conversion.md) — [camelCase](#camelcase), [pascalCase](#pascalcase), [snakeCase](#snakecase), [kebabCase](#kebabcase), [slugify](#slugify), [capitalize](#capitalize), [titleCase](#titlecase)
 - [**Validation**](api/validation.md) — [isEmail](#isemail), [isUrl](#isurl), [isPhoneNumber](#isphonenumber)
 - [**Extraction**](api/extraction.md) — [extractEmails](#extractemails), [extractUrls](#extracturls), [extractMentions](#extractmentions), [extractHashtags](#extracthashtags)
-- [**Security**](api/security.md) — [redact](#redact), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml), [sanitize](#sanitize)
+- [**Security**](api/security.md) — [redact](#redact), [scan](#scan), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml), [sanitize](#sanitize)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate), [wordFrequency](#wordfrequency)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
 - [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal), [ordinalToWords](#ordinaltowords)
@@ -88,6 +88,10 @@ Full docs: [docs/api/extraction.md#extracthashtags](api/extraction.md#extracthas
 ### redact
 
 Full docs: [docs/api/security.md#redact](api/security.md#redact)
+
+### scan
+
+Full docs: [docs/api/security.md#scan](api/security.md#scan)
 
 ### maskText
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,7 @@ textConvert/
         phoneNumber.ts   # Phone number validation
       internal/
         scan.ts          # Shared linear-scan helpers (not publicly exported) used by extract.ts and redact.ts
+        detectors.ts     # Shared, position-aware PII/secret detection logic (not publicly exported) used by redact.ts, extract.ts, and scan.ts
       conventions.ts    # Case conversion functions (camelCase, snakeCase, capitalize, titleCase, ...)
       slugify.ts        # URL-safe slug generation
       clear.ts          # Punctuation removal
@@ -28,6 +29,7 @@ textConvert/
       truncate.ts        # Length-limited text truncation with ellipsis
       mask.ts            # Partial string masking for display
       redact.ts          # PII/secret detection and masking (built on mask.ts)
+      scan.ts            # PII/secret detection as structured matches (same detection logic as redact.ts, non-destructive)
       extract.ts          # Email/URL extraction from free-form text
     numbers/
       numbersToWords.ts # Number to words conversion
@@ -47,7 +49,7 @@ textConvert/
 
 - **text/analysis/**: Text statistics, language detection, and related analysis tools.
 - **text/validation/**: Validation functions (email, URL, phone number).
-- **text/internal/**: Shared logic used by more than one public function but not exported from the package itself — currently the linear-scan helpers behind `extract.ts` and `redact.ts`.
+- **text/internal/**: Shared logic used by more than one public function but not exported from the package itself — the linear-scan helpers (`scan.ts`) and the position-aware PII/secret detection logic (`detectors.ts`) behind `extract.ts`, `redact.ts`, and `scan.ts` (the public one).
 - **text/conventions.ts**: Case conversion (camelCase, PascalCase, snake_case, kebab-case, capitalize, titleCase).
 - **text/slugify.ts**: URL-safe slug generation with Unicode accent normalization.
 - **text/clear.ts**: Remove punctuation and clean text.
@@ -57,6 +59,7 @@ textConvert/
 - **text/truncate.ts**: Shorten text to a max length with an ellipsis.
 - **text/mask.ts**: Partially mask a string for display (the primitive `redact.ts` is built on).
 - **text/redact.ts**: Detect and mask PII (email, phone, credit card, public IPv4) and secrets (API keys, JWTs) in free-form text.
+- **text/scan.ts**: Same PII/secret detection as `redact.ts` (built on the same shared `text/internal/detectors.ts` logic), returning structured `{ type, value, start, end }` matches instead of masking them.
 - **text/extract.ts**: Find every email/URL embedded in a block of text.
 - **numbers/numbersToWords.ts**: Convert numbers to English words.
 - **assets/regex.ts**: Centralized regex patterns for reuse.
@@ -82,7 +85,7 @@ textConvert/
 - **Adding New Functions**: Follow the guide in `docs/ADDING_FUNCTION.md`.
 - **Adding New Validators**: Place in `text/validation/`, export via `textConvert.ts`, and document.
 - **Adding New Analysis Tools**: Place in `text/analysis/`, export and document as above.
-- **Adding New Text Scanners**: If it scans free-form text for candidate substrings (like `extract.ts`/`redact.ts` do), check `text/internal/scan.ts` first — reuse its helpers instead of writing another backtracking regex.
+- **Adding New Text Scanners**: If it scans free-form text for candidate substrings (like `extract.ts`/`redact.ts` do), check `text/internal/scan.ts` first — reuse its helpers instead of writing another backtracking regex. If it's a new PII/secret type specifically, add it to `text/internal/detectors.ts` so both `redact.ts` and `scan.ts` pick it up from one place.
 
 ---
 

--- a/docs/api/security.md
+++ b/docs/api/security.md
@@ -1,12 +1,13 @@
 # Security
 
-`redact`, `maskText`, `escapeHtml`, `unescapeHtml`, `sanitize`.
+`redact`, `scan`, `maskText`, `escapeHtml`, `unescapeHtml`, `sanitize`.
 
 ---
 
 ## Table of Contents
 
 - [redact](#redact)
+- [scan](#scan)
 - [maskText](#masktext)
 - [escapeHtml](#escapehtml)
 - [unescapeHtml](#unescapehtml)
@@ -65,6 +66,42 @@ redact('Server 10.0.0.5 hit by 203.0.113.42', { types: ['ip'] });
 - JWTs are always masked in full (no visible portion), the same convention as `apiKey` — there's no equivalent to a credit card's "last 4 visible" for a bearer token.
 - Every occurrence of a repeated match is masked, not just the first.
 - Phone number, credit card, IPv4, and JWT candidates are all found by scanning for maximal runs of an allowed-character set, which is shared internal logic — they differ only in which characters are allowed and the validation applied afterward.
+
+---
+
+## scan
+
+Scans free-form text for the same embedded PII (emails, phone numbers, credit card numbers, public IPv4 addresses) and secrets (API keys/tokens, JWTs) that `redact` detects, but returns each match as structured data instead of masking it in place — for callers that want to inspect, log, or make their own decision about what was found, rather than have it masked automatically.
+
+`scan` reuses exactly the same detection logic `redact` does (they share one internal implementation), so it carries the same known gaps and false-positive/negative characteristics documented above for `redact` — the `'ip'` and `'jwt'` caveats apply here too. `scan` is best-effort pattern matching, not a complete PII/secret detector.
+
+**Parameters:**
+
+- `text: string` — The text to scan.
+- `options.types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey' | 'ip' | 'jwt'>` — Which types to look for. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'`, `'ip'`, and `'jwt'` are opt-in only — same reasoning as `redact`.
+
+**Returns:**
+
+- `ScanMatch[]` — Every match found, in the order it appears in the text. Each match is `{ type, value, start, end }`, where `type` is which kind of match it is, `value` is the matched substring, and `start`/`end` are its position in the input text (`end` exclusive, like `String.slice`).
+
+**Example:**
+
+```js
+import { scan } from 'textconvert';
+
+scan('Contact jordan@example.com, card 4111 1111 1111 1111');
+// [
+//   { type: 'email', value: 'jordan@example.com', start: 8, end: 26 },
+//   { type: 'creditCard', value: '4111 1111 1111 1111', start: 33, end: 52 },
+// ]
+```
+
+**Edge Cases:**
+
+- Returns `[]` for empty input or when nothing matches, rather than an error message — `scan` returns an array, not a string, so the shared string sentinel doesn't apply here (matching how `extractEmails`/`extractUrls` handle empty/no-match input).
+- Every occurrence of a repeated value gets its own entry with its own position, unlike `redact`, which dedupes before masking — scanning the same email twice returns two separate matches.
+- Results are sorted by `start` across all requested types, not grouped by type — so matches come back in the order they actually appear in the text.
+- `'apiKey'`, `'ip'`, and `'jwt'` are opt-in only, not included by default — same false-positive-risk reasoning as `redact`.
 
 ---
 

--- a/docs/api/security.md
+++ b/docs/api/security.md
@@ -17,7 +17,7 @@
 
 ## redact
 
-Scans free-form text for embedded PII (emails, phone numbers, credit card numbers, public IPv4 addresses) and secrets (API keys/tokens, JWTs) and masks each match in place, using `extractEmails` to locate emails and `maskText` to mask every match — for sanitizing logs, support tickets, or user-generated content before storage or display.
+Scans free-form text for embedded PII (emails, phone numbers, credit card numbers, public IPv4 addresses) and secrets (API keys/tokens, JWTs) and masks each match in place with `maskText` — for sanitizing logs, support tickets, or user-generated content before storage or display.
 
 `redact` is best-effort pattern matching, not a complete PII/secret detector. False negatives are possible — pair it with review for anything where a missed match matters, rather than relying on it as the only safeguard. Two gaps worth knowing about specifically, not just as a buried edge case:
 
@@ -64,8 +64,9 @@ redact('Server 10.0.0.5 hit by 203.0.113.42', { types: ['ip'] });
 - JWT detection requires the real three-segment structure (`header.payload.signature`), not just an `eyJ` prefix — the header segment must base64url-decode to JSON containing a string `alg` field. This is deliberately stronger than a prefix check, which would also match any base64-encoded JSON (a JWT-shaped `eyJ...` string that fails this check is not matched, e.g. `'not.a.jwt'`).
 - JWTs with an empty signature segment (unsigned, `alg: "none"` tokens) are not matched — a real but rare JWT variant, out of scope for now.
 - JWTs are always masked in full (no visible portion), the same convention as `apiKey` — there's no equivalent to a credit card's "last 4 visible" for a bearer token.
-- Every occurrence of a repeated match is masked, not just the first.
+- Every occurrence of a repeated match is masked, not just the first — each occurrence is masked at its own position, not by a whole-text find-and-replace on the matched value, so masking one occurrence can never affect unrelated text elsewhere that merely contains the same substring (e.g. a matched phone number that's also a substring of a longer, unrelated digit string like an order number).
 - Phone number, credit card, IPv4, and JWT candidates are all found by scanning for maximal runs of an allowed-character set, which is shared internal logic — they differ only in which characters are allowed and the validation applied afterward.
+- When two different types' matches overlap the same span (e.g. a digit run that's shaped like both a phone number and a credit card), only one is masked — priority follows detector order: `email`, `phone`, `creditCard`, `apiKey`, `ip`, `jwt`.
 
 ---
 
@@ -99,7 +100,7 @@ scan('Contact jordan@example.com, card 4111 1111 1111 1111');
 **Edge Cases:**
 
 - Returns `[]` for empty input or when nothing matches, rather than an error message — `scan` returns an array, not a string, so the shared string sentinel doesn't apply here (matching how `extractEmails`/`extractUrls` handle empty/no-match input).
-- Every occurrence of a repeated value gets its own entry with its own position, unlike `redact`, which dedupes before masking — scanning the same email twice returns two separate matches.
+- Every occurrence of a repeated value gets its own entry with its own position — scanning the same email twice returns two separate matches.
 - Results are sorted by `start` across all requested types, not grouped by type — so matches come back in the order they actually appear in the text.
 - `'apiKey'`, `'ip'`, and `'jwt'` are opt-in only, not included by default — same false-positive-risk reasoning as `redact`.
 

--- a/src/text/extract.ts
+++ b/src/text/extract.ts
@@ -1,16 +1,6 @@
-import { findPrefixedTokens, stripTrailing } from './internal/scan';
-import { isEmail } from './validation/email';
+import { findPrefixedTokens, stripTrailing, trailingPunctuationChars } from './internal/scan';
+import { findEmailMatches } from './internal/detectors';
 import { isUrl } from './validation/url';
-
-// Characters allowed in an email's local-part / domain, checked one
-// character at a time (O(1) per check) rather than with a `+`-quantified
-// regex scanned across the whole string, which is vulnerable to ReDoS on
-// long runs of a single allowed character (e.g. many repeated '!').
-const localPartChars = new Set(
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!#$%&'*+/=?^_`{|}~-",
-);
-const domainChars = new Set('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-');
-const trailingPunctuationChars = new Set([...'.,;:!?)]}\'"']);
 
 // Characters that end a URL candidate: whitespace and the delimiters
 // commonly used to wrap a URL in prose (quotes, angle brackets, parens),
@@ -24,36 +14,8 @@ function stripTrailingPunctuation(value: string): string {
 }
 
 /**
- * Finds "local-part@domain"-shaped candidate substrings in text via a
- * single linear pass, without regex backtracking risk.
- */
-function findEmailCandidates(text: string): string[] {
-  const candidates: string[] = [];
-  let runStart = 0;
-
-  for (let i = 0; i < text.length; i++) {
-    const char = text[i];
-
-    if (char === '@' && i > runStart) {
-      let end = i + 1;
-      while (end < text.length && domainChars.has(text[end])) end++;
-
-      if (end > i + 1) candidates.push(text.slice(runStart, end));
-
-      i = end - 1;
-      runStart = end;
-      continue;
-    }
-
-    if (!localPartChars.has(char)) runStart = i + 1;
-  }
-
-  return candidates;
-}
-
-/**
  * Extracts all email addresses found in a block of text, rather than
- * validating a single string like {@link isEmail} does.
+ * validating a single string like `isEmail` does.
  *
  * @param text Text to search for email addresses.
  * @returns An array of the email addresses found, in the order they appear.
@@ -64,7 +26,7 @@ function findEmailCandidates(text: string): string[] {
 export function extractEmails(text: string): string[] {
   if (!text) return [];
 
-  return findEmailCandidates(text).map(stripTrailingPunctuation).filter(isEmail);
+  return findEmailMatches(text).map((match) => match.value);
 }
 
 /**

--- a/src/text/internal/detectors.ts
+++ b/src/text/internal/detectors.ts
@@ -15,6 +15,11 @@ import { isPhoneNumber } from '../validation/phoneNumber';
 /** The PII/secret shapes both redact() and scan() know how to detect. */
 export type DetectionType = 'email' | 'phone' | 'creditCard' | 'apiKey' | 'ip' | 'jwt';
 
+/** A {@link PositionedMatch} tagged with which detector found it. */
+export interface TypedMatch extends PositionedMatch {
+  type: DetectionType;
+}
+
 // ---- Email --------------------------------------------------------------
 
 // Characters allowed in an email's local-part / domain, checked one
@@ -297,4 +302,35 @@ function isValidJwt(candidate: string): boolean {
  */
 export function findJwtMatches(text: string): PositionedMatch[] {
   return scanMaximalRunsWithPositions(text, jwtChars).filter((match) => isValidJwt(match.value));
+}
+
+// ---- Shared dispatch, used by both redact() and scan() ---------------------
+
+// Also the priority order for resolving overlapping matches of different
+// types (e.g. a digit run shaped like both a phone number and a credit
+// card): whichever type appears first here wins, see findMatchesByType.
+const findersByType: Record<DetectionType, (text: string) => PositionedMatch[]> = {
+  email: findEmailMatches,
+  phone: findPhoneNumberMatches,
+  creditCard: findCreditCardMatches,
+  apiKey: findApiKeyMatches,
+  ip: findPublicIpv4Matches,
+  jwt: findJwtMatches,
+};
+
+/**
+ * Runs every detector in `types` over `text` and returns all their matches
+ * together, each tagged with the type that found it, in detector-priority
+ * order (not yet sorted by position) -- shared by `redact` and `scan` so
+ * they can't drift out of sync on which detector backs which type.
+ */
+export function findMatchesByType(text: string, types: DetectionType[]): TypedMatch[] {
+  const matches: TypedMatch[] = [];
+
+  for (const type of Object.keys(findersByType) as DetectionType[]) {
+    if (!types.includes(type)) continue;
+    for (const match of findersByType[type](text)) matches.push({ type, ...match });
+  }
+
+  return matches;
 }

--- a/src/text/internal/detectors.ts
+++ b/src/text/internal/detectors.ts
@@ -1,0 +1,300 @@
+import {
+  PositionedMatch,
+  scanMaximalRunsWithPositions,
+  stripTrailing,
+  trailingPunctuationChars,
+} from './scan';
+import { isEmail } from '../validation/email';
+import { isPhoneNumber } from '../validation/phoneNumber';
+
+// Shared, position-aware detection logic behind both redact() and scan() --
+// each function here mirrors a specific PII/secret shape, returning every
+// match's value alongside its position in the text. Kept in one place so
+// the two public functions can't drift out of sync with each other.
+
+/** The PII/secret shapes both redact() and scan() know how to detect. */
+export type DetectionType = 'email' | 'phone' | 'creditCard' | 'apiKey' | 'ip' | 'jwt';
+
+// ---- Email --------------------------------------------------------------
+
+// Characters allowed in an email's local-part / domain, checked one
+// character at a time (O(1) per check) rather than with a `+`-quantified
+// regex scanned across the whole string, which is vulnerable to ReDoS on
+// long runs of a single allowed character (e.g. many repeated '!').
+const localPartChars = new Set(
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!#$%&'*+/=?^_`{|}~-",
+);
+const domainChars = new Set('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-');
+
+/**
+ * Finds "local-part@domain"-shaped email matches in text, validated with
+ * {@link isEmail}, along with each match's position. Shared by
+ * `extractEmails` and `scan`.
+ */
+export function findEmailMatches(text: string): PositionedMatch[] {
+  const matches: PositionedMatch[] = [];
+  let runStart = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (char === '@' && i > runStart) {
+      let end = i + 1;
+      while (end < text.length && domainChars.has(text[end])) end++;
+
+      if (end > i + 1) {
+        const rawValue = text.slice(runStart, end);
+        const value = stripTrailing(rawValue, trailingPunctuationChars);
+
+        if (isEmail(value)) {
+          matches.push({ value, start: runStart, end: runStart + value.length });
+        }
+      }
+
+      i = end - 1;
+      runStart = end;
+      continue;
+    }
+
+    if (!localPartChars.has(char)) runStart = i + 1;
+  }
+
+  return matches;
+}
+
+// ---- Phone number ---------------------------------------------------------
+
+// Characters allowed in a phone number candidate, checked one character at
+// a time (O(1) per check, no regex backtracking risk) rather than with a
+// `+`-quantified regex scanned across the whole string.
+const phoneChars = new Set([...'+0123456789 ().-']);
+const dotChars = new Set(['.']);
+
+/**
+ * Finds phone-number-shaped matches, validated with {@link isPhoneNumber},
+ * along with each match's position. A trailing '.' is always stripped
+ * first: it's a valid mid-number separator (as in '555.123.4567') but also
+ * commonly a sentence-ending period, which the character-run scan can't
+ * otherwise tell apart, and a phone number never legitimately ends on one.
+ */
+export function findPhoneNumberMatches(text: string): PositionedMatch[] {
+  return scanMaximalRunsWithPositions(text, phoneChars)
+    .map((match) => {
+      const value = stripTrailing(match.value, dotChars);
+      return { value, start: match.start, end: match.start + value.length };
+    })
+    .filter((match) => isPhoneNumber(match.value));
+}
+
+// ---- Credit card ----------------------------------------------------------
+
+// Characters allowed in a credit card candidate: digits and the separators
+// commonly used when writing one out (space, dash). No dots/parens/plus —
+// unlike phone numbers, card numbers don't use them.
+const creditCardChars = new Set([...'0123456789 -']);
+
+// Luhn checksum, used to tell an actual card number apart from an arbitrary
+// digit sequence of the same length (order IDs, invoice numbers, ...).
+function isValidLuhn(digits: string): boolean {
+  let sum = 0;
+  let shouldDouble = false;
+
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let digit = digits.charCodeAt(i) - 48;
+
+    if (shouldDouble) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+
+    sum += digit;
+    shouldDouble = !shouldDouble;
+  }
+
+  return sum % 10 === 0;
+}
+
+/**
+ * Finds credit-card-shaped matches whose digits (ignoring spaces/dashes)
+ * fall in the standard 13-19 digit range (ISO/IEC 7812) and pass a Luhn
+ * checksum, along with each match's position.
+ */
+export function findCreditCardMatches(text: string): PositionedMatch[] {
+  return scanMaximalRunsWithPositions(text, creditCardChars).filter((match) => {
+    const digits = match.value.replace(/[ -]/g, '');
+    return digits.length >= 13 && digits.length <= 19 && isValidLuhn(digits);
+  });
+}
+
+// ---- API key / token -------------------------------------------------------
+
+// Characters allowed after a known API key/token prefix — letters, digits,
+// and underscore. Anything else ends the run.
+const tokenChars = new Set([...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_']);
+
+// Known, high-specificity secret prefixes and the minimum total match
+// length (prefix + token) required before it counts as a match.
+// Deliberately narrow and prefix-based rather than a generic "looks
+// random" entropy heuristic, which produces heavy false positives on
+// hashes, UUIDs, and ordinary identifiers (see #320's research notes).
+const apiKeyPrefixes: Array<{ prefix: string; minLength: number }> = [
+  { prefix: 'AKIA', minLength: 20 }, // AWS access key: AKIA + 16 chars
+  { prefix: 'ghp_', minLength: 40 }, // GitHub classic PAT: ghp_ + 36 chars
+  { prefix: 'github_pat_', minLength: 82 }, // GitHub fine-grained PAT
+  { prefix: 'sk_live_', minLength: 32 }, // Stripe live secret key
+];
+
+/**
+ * Finds API key/token matches: a known prefix followed by a run of token
+ * characters meeting that prefix's minimum length, found via
+ * `indexOf`-based scanning rather than a regex alternation, along with
+ * each match's position.
+ */
+export function findApiKeyMatches(text: string): PositionedMatch[] {
+  const matches: PositionedMatch[] = [];
+
+  for (const { prefix, minLength } of apiKeyPrefixes) {
+    let searchFrom = 0;
+
+    while (searchFrom < text.length) {
+      const start = text.indexOf(prefix, searchFrom);
+      if (start === -1) break;
+
+      let end = start + prefix.length;
+      while (end < text.length && tokenChars.has(text[end])) end++;
+
+      if (end - start >= minLength) matches.push({ value: text.slice(start, end), start, end });
+
+      // end is always > start here: every prefix is non-empty, so end
+      // starts at start + prefix.length before the token-char loop even
+      // runs, unlike a scan that could match zero characters.
+      searchFrom = end;
+    }
+  }
+
+  return matches;
+}
+
+// ---- IPv4 -------------------------------------------------------------------
+
+// Characters allowed in an IPv4 candidate: digits and the dot separator.
+const ipv4Chars = new Set([...'0123456789.']);
+
+/**
+ * Validates a candidate as exactly 4 dot-separated octets, each 0-255, with
+ * no leading zeros (e.g. '01') other than a bare '0' -- some parsers treat
+ * a leading-zero octet as octal, so rejecting it outright avoids that
+ * ambiguity rather than picking a side. Returns the 4 parsed octets, or
+ * `null` if the candidate isn't a validly-shaped IPv4 address.
+ */
+function parseIpv4Octets(candidate: string): number[] | null {
+  const parts = candidate.split('.');
+  if (parts.length !== 4) return null;
+
+  const octets: number[] = [];
+
+  for (const part of parts) {
+    if (part.length === 0 || part.length > 3) return null;
+    if (part.length > 1 && part[0] === '0') return null;
+
+    // No separate "is this all digits" check needed: candidates only ever
+    // reach here already restricted to ipv4Chars (digits and '.') by the
+    // scan that produced them, so every part is guaranteed digits-only.
+    const value = Number(part);
+    if (value > 255) return null;
+
+    octets.push(value);
+  }
+
+  return octets;
+}
+
+// RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), plus
+// loopback (127.0.0.0/8) and link-local (169.254.0.0/16) -- never matched,
+// with no opt-in override, since these are non-globally-unique addresses
+// that appear on every organization's own network. Masking one in a debug
+// log actively destroys its usefulness (e.g. "which internal server made
+// this request") with no corresponding privacy benefit, unlike a public IP.
+function isPrivateOrReservedIpv4(octets: number[]): boolean {
+  const [a, b] = octets;
+
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 127) return true; // 127.0.0.0/8 (loopback)
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 (link-local)
+
+  return false;
+}
+
+/**
+ * Finds public IPv4 address matches -- candidates that parse as 4 valid
+ * octets and aren't a private/loopback/link-local address -- along with
+ * each match's position.
+ */
+export function findPublicIpv4Matches(text: string): PositionedMatch[] {
+  return scanMaximalRunsWithPositions(text, ipv4Chars).filter((match) => {
+    const octets = parseIpv4Octets(match.value);
+    return octets !== null && !isPrivateOrReservedIpv4(octets);
+  });
+}
+
+// ---- JWT --------------------------------------------------------------------
+
+// Characters allowed in a JWT candidate: the base64url alphabet plus the
+// two dots separating its three segments.
+const jwtChars = new Set([...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.']);
+
+/**
+ * Decodes a base64url segment (the `-`/`_` alphabet, no padding) to a UTF-8
+ * string using the standard Web Crypto/encoding globals available in both
+ * Node and browsers -- same "universal Web API, not a Node-only import"
+ * approach as {@link randomString}'s use of `globalThis.crypto`. Returns
+ * `null` rather than throwing on invalid input, since this runs against
+ * attacker-controlled candidate text.
+ */
+function base64UrlDecode(segment: string): string | null {
+  try {
+    const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+    return globalThis.atob(padded);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validates a candidate as a structurally-real JWT: exactly 3 non-empty
+ * dot-separated segments, where the first (the header) base64url-decodes
+ * to JSON containing a string `alg` field.
+ *
+ * Deliberately does not verify the signature, check expiry, or otherwise
+ * confirm the token is real/valid -- only that it's shaped like one.
+ */
+function isValidJwt(candidate: string): boolean {
+  const segments = candidate.split('.');
+  if (segments.length !== 3 || segments.some((segment) => segment.length === 0)) return false;
+
+  const decodedHeader = base64UrlDecode(segments[0]);
+  if (decodedHeader === null) return false;
+
+  try {
+    const header: unknown = JSON.parse(decodedHeader);
+    return (
+      typeof header === 'object' &&
+      header !== null &&
+      'alg' in header &&
+      typeof (header as { alg: unknown }).alg === 'string'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Finds structurally-valid JWT matches, validated with {@link isValidJwt},
+ * along with each match's position.
+ */
+export function findJwtMatches(text: string): PositionedMatch[] {
+  return scanMaximalRunsWithPositions(text, jwtChars).filter((match) => isValidJwt(match.value));
+}

--- a/src/text/internal/scan.ts
+++ b/src/text/internal/scan.ts
@@ -1,11 +1,27 @@
+export interface PositionedMatch {
+  value: string;
+  start: number;
+  end: number;
+}
+
+// Trailing punctuation that's almost always part of the surrounding
+// sentence, not the match itself (e.g. a sentence-ending period right
+// after an email address or URL). Shared by extractEmails, extractUrls,
+// and scan's email matching.
+export const trailingPunctuationChars = new Set([...'.,;:!?)]}\'"']);
+
 /**
  * Finds maximal runs of characters from `allowedChars` in `text`, trimming
- * leading/trailing spaces from each run before returning it. A single
- * linear pass, no regex backtracking risk — shared by any scanner that
- * just needs "runs of these characters" (phone numbers, credit cards).
+ * leading/trailing spaces from each run before returning it, along with
+ * each run's position in `text`. A single linear pass, no regex
+ * backtracking risk — shared by any scanner that just needs "runs of
+ * these characters" (phone numbers, credit cards, IPv4 addresses, JWTs).
  */
-export function scanMaximalRuns(text: string, allowedChars: Set<string>): string[] {
-  const candidates: string[] = [];
+export function scanMaximalRunsWithPositions(
+  text: string,
+  allowedChars: Set<string>,
+): PositionedMatch[] {
+  const matches: PositionedMatch[] = [];
   let i = 0;
 
   while (i < text.length) {
@@ -22,12 +38,14 @@ export function scanMaximalRuns(text: string, allowedChars: Set<string>): string
     let trimmedEnd = end;
     while (trimmedEnd > start && text[trimmedEnd - 1] === ' ') trimmedEnd--;
 
-    if (trimmedEnd > start) candidates.push(text.slice(start, trimmedEnd));
+    if (trimmedEnd > start) {
+      matches.push({ value: text.slice(start, trimmedEnd), start, end: trimmedEnd });
+    }
 
     i = end;
   }
 
-  return candidates;
+  return matches;
 }
 
 /**

--- a/src/text/redact.ts
+++ b/src/text/redact.ts
@@ -1,267 +1,17 @@
-import { scanMaximalRuns, stripTrailing } from './internal/scan';
+import {
+  DetectionType,
+  findApiKeyMatches,
+  findCreditCardMatches,
+  findJwtMatches,
+  findPhoneNumberMatches,
+  findPublicIpv4Matches,
+} from './internal/detectors';
 import { extractEmails } from './extract';
 import { maskText } from './mask';
-import { isPhoneNumber } from './validation/phoneNumber';
-
-// Characters allowed in a phone number candidate, checked one character at
-// a time (O(1) per check, no regex backtracking risk) rather than with a
-// `+`-quantified regex scanned across the whole string.
-const phoneChars = new Set([...'+0123456789 ().-']);
-
-/**
- * Finds phone-number-shaped candidate substrings: maximal runs of
- * phone-safe characters, trimmed of surrounding whitespace. Letters and
- * any other character end a run, so ordinary prose naturally breaks
- * candidates apart.
- */
-function findPhoneCandidates(text: string): string[] {
-  return scanMaximalRuns(text, phoneChars);
-}
-
-const dotChars = new Set(['.']);
-
-// A trailing '.' is ambiguous: it's a valid mid-number separator (as in
-// '555.123.4567') but also commonly a sentence-ending period, which
-// findPhoneCandidates can't otherwise tell apart. Since a phone number
-// never legitimately ends the match on a '.', it's always stripped before
-// validating.
-function stripTrailingDots(value: string): string {
-  return stripTrailing(value, dotChars);
-}
-
-/** Phone numbers found in text, validated with {@link isPhoneNumber}. */
-function findPhoneNumbers(text: string): string[] {
-  return findPhoneCandidates(text).map(stripTrailingDots).filter(isPhoneNumber);
-}
-
-// Characters allowed in a credit card candidate: digits and the separators
-// commonly used when writing one out (space, dash). No dots/parens/plus —
-// unlike phone numbers, card numbers don't use them.
-const creditCardChars = new Set([...'0123456789 -']);
-
-/**
- * Finds credit-card-shaped candidate substrings, the same maximal-run
- * approach as {@link findPhoneCandidates}.
- */
-function findCreditCardCandidates(text: string): string[] {
-  return scanMaximalRuns(text, creditCardChars);
-}
-
-// Luhn checksum, used to tell an actual card number apart from an arbitrary
-// digit sequence of the same length (order IDs, invoice numbers, ...).
-function isValidLuhn(digits: string): boolean {
-  let sum = 0;
-  let shouldDouble = false;
-
-  for (let i = digits.length - 1; i >= 0; i--) {
-    let digit = digits.charCodeAt(i) - 48;
-
-    if (shouldDouble) {
-      digit *= 2;
-      if (digit > 9) digit -= 9;
-    }
-
-    sum += digit;
-    shouldDouble = !shouldDouble;
-  }
-
-  return sum % 10 === 0;
-}
-
-/**
- * Credit card numbers found in text: candidates whose digits (ignoring
- * spaces/dashes) fall in the standard 13-19 digit range (ISO/IEC 7812) and
- * pass a Luhn checksum.
- */
-function findCreditCards(text: string): string[] {
-  return findCreditCardCandidates(text).filter((candidate) => {
-    const digits = candidate.replace(/[ -]/g, '');
-    return digits.length >= 13 && digits.length <= 19 && isValidLuhn(digits);
-  });
-}
-
-// Characters allowed after a known API key/token prefix — letters, digits,
-// and underscore. Anything else ends the run.
-const tokenChars = new Set([...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_']);
-
-// Known, high-specificity secret prefixes and the minimum total match
-// length (prefix + token) required before it counts as a candidate. Deliberately
-// narrow and prefix-based rather than a generic "looks random" entropy
-// heuristic, which produces heavy false positives on hashes, UUIDs, and
-// ordinary identifiers (see #320's research notes).
-const apiKeyPrefixes: Array<{ prefix: string; minLength: number }> = [
-  { prefix: 'AKIA', minLength: 20 }, // AWS access key: AKIA + 16 chars
-  { prefix: 'ghp_', minLength: 40 }, // GitHub classic PAT: ghp_ + 36 chars
-  { prefix: 'github_pat_', minLength: 82 }, // GitHub fine-grained PAT
-  { prefix: 'sk_live_', minLength: 32 }, // Stripe live secret key
-];
-
-/**
- * Finds API key/token candidates: a known prefix followed by a run of
- * token characters meeting that prefix's minimum length, found via
- * `indexOf`-based scanning rather than a regex alternation.
- */
-function findApiKeys(text: string): string[] {
-  const candidates: string[] = [];
-
-  for (const { prefix, minLength } of apiKeyPrefixes) {
-    let searchFrom = 0;
-
-    while (searchFrom < text.length) {
-      const start = text.indexOf(prefix, searchFrom);
-      if (start === -1) break;
-
-      let end = start + prefix.length;
-      while (end < text.length && tokenChars.has(text[end])) end++;
-
-      if (end - start >= minLength) candidates.push(text.slice(start, end));
-
-      searchFrom = end > start ? end : start + 1;
-    }
-  }
-
-  return candidates;
-}
-
-// Characters allowed in an IPv4 candidate: digits and the dot separator.
-const ipv4Chars = new Set([...'0123456789.']);
-
-/**
- * Finds IPv4-shaped candidate substrings, the same maximal-run approach as
- * {@link findPhoneCandidates}.
- */
-function findIpv4Candidates(text: string): string[] {
-  return scanMaximalRuns(text, ipv4Chars);
-}
-
-/**
- * Validates a candidate as exactly 4 dot-separated octets, each 0-255, with
- * no leading zeros (e.g. '01') other than a bare '0' -- some parsers treat
- * a leading-zero octet as octal, so rejecting it outright avoids that
- * ambiguity rather than picking a side. Returns the 4 parsed octets, or
- * `null` if the candidate isn't a validly-shaped IPv4 address.
- */
-function parseIpv4Octets(candidate: string): number[] | null {
-  const parts = candidate.split('.');
-  if (parts.length !== 4) return null;
-
-  const octets: number[] = [];
-
-  for (const part of parts) {
-    if (part.length === 0 || part.length > 3) return null;
-    if (part.length > 1 && part[0] === '0') return null;
-
-    // No separate "is this all digits" check needed: candidates only ever
-    // reach here from findIpv4Candidates, which already restricted the
-    // whole string to ipv4Chars (digits and '.') before this split -- so
-    // every part is guaranteed to be digits-only already.
-    const value = Number(part);
-    if (value > 255) return null;
-
-    octets.push(value);
-  }
-
-  return octets;
-}
-
-// RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), plus
-// loopback (127.0.0.0/8) and link-local (169.254.0.0/16) -- never matched,
-// with no opt-in override, since these are non-globally-unique addresses
-// that appear on every organization's own network. Masking one in a debug
-// log actively destroys its usefulness (e.g. "which internal server made
-// this request") with no corresponding privacy benefit, unlike a public IP.
-function isPrivateOrReservedIpv4(octets: number[]): boolean {
-  const [a, b] = octets;
-
-  if (a === 10) return true; // 10.0.0.0/8
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-  if (a === 192 && b === 168) return true; // 192.168.0.0/16
-  if (a === 127) return true; // 127.0.0.0/8 (loopback)
-  if (a === 169 && b === 254) return true; // 169.254.0.0/16 (link-local)
-
-  return false;
-}
-
-/**
- * Public IPv4 addresses found in text -- candidates that parse as 4 valid
- * octets and aren't a private/loopback/link-local address.
- */
-function findPublicIpv4Addresses(text: string): string[] {
-  return findIpv4Candidates(text).filter((candidate) => {
-    const octets = parseIpv4Octets(candidate);
-    return octets !== null && !isPrivateOrReservedIpv4(octets);
-  });
-}
-
-// Characters allowed in a JWT candidate: the base64url alphabet plus the
-// two dots separating its three segments.
-const jwtChars = new Set([...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.']);
-
-/**
- * Finds JWT-shaped candidate substrings, the same maximal-run approach as
- * {@link findPhoneCandidates}.
- */
-function findJwtCandidates(text: string): string[] {
-  return scanMaximalRuns(text, jwtChars);
-}
-
-/**
- * Decodes a base64url segment (the `-`/`_` alphabet, no padding) to a UTF-8
- * string using the standard Web Crypto/encoding globals available in both
- * Node and browsers -- same "universal Web API, not a Node-only import"
- * approach as {@link randomString}'s use of `globalThis.crypto`. Returns
- * `null` rather than throwing on invalid input, since this runs against
- * attacker-controlled candidate text.
- */
-function base64UrlDecode(segment: string): string | null {
-  try {
-    const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
-    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
-    return globalThis.atob(padded);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Validates a candidate as a structurally-real JWT: exactly 3 non-empty
- * dot-separated segments, where the first (the header) base64url-decodes
- * to JSON containing a string `alg` field. This is the properly-scoped
- * replacement for a bare `eyJ`-prefix check (rejected in #320 -- `eyJ` is
- * just base64 for `{`, the start of any base64-encoded JSON, not something
- * JWT-specific).
- *
- * Deliberately does not verify the signature, check expiry, or otherwise
- * confirm the token is real/valid -- only that it's shaped like one.
- */
-function isValidJwt(candidate: string): boolean {
-  const segments = candidate.split('.');
-  if (segments.length !== 3 || segments.some((segment) => segment.length === 0)) return false;
-
-  const decodedHeader = base64UrlDecode(segments[0]);
-  if (decodedHeader === null) return false;
-
-  try {
-    const header: unknown = JSON.parse(decodedHeader);
-    return (
-      typeof header === 'object' &&
-      header !== null &&
-      'alg' in header &&
-      typeof (header as { alg: unknown }).alg === 'string'
-    );
-  } catch {
-    return false;
-  }
-}
-
-/** JWTs found in text, validated with {@link isValidJwt}. */
-function findJwts(text: string): string[] {
-  return findJwtCandidates(text).filter(isValidJwt);
-}
 
 export interface RedactOptions {
   /** Which types to redact. Default is 'email', 'phone', and 'creditCard'. 'apiKey', 'ip', and 'jwt' are opt-in only, given their higher false-positive risk (or, for 'jwt', simply being a bearer secret rather than classic PII). */
-  types?: Array<'email' | 'phone' | 'creditCard' | 'apiKey' | 'ip' | 'jwt'>;
+  types?: DetectionType[];
   /** Character(s) to use for masked positions, passed through to maskText. Default is '*'. */
   maskChar?: string;
 }
@@ -318,13 +68,13 @@ export function redact(text: string, options: RedactOptions = {}): string {
   }
 
   if (types.includes('phone')) {
-    for (const phone of new Set(findPhoneNumbers(text))) {
+    for (const phone of new Set(findPhoneNumberMatches(text).map((match) => match.value))) {
       result = result.split(phone).join(maskText(phone, { maskChar }));
     }
   }
 
   if (types.includes('creditCard')) {
-    for (const card of new Set(findCreditCards(text))) {
+    for (const card of new Set(findCreditCardMatches(text).map((match) => match.value))) {
       // Last 4 digits visible matches the standard "card ending in 1234"
       // convention, rather than full masking.
       result = result
@@ -334,19 +84,19 @@ export function redact(text: string, options: RedactOptions = {}): string {
   }
 
   if (types.includes('apiKey')) {
-    for (const key of new Set(findApiKeys(text))) {
+    for (const key of new Set(findApiKeyMatches(text).map((match) => match.value))) {
       result = result.split(key).join(maskText(key, { visibleStart: 0, visibleEnd: 0, maskChar }));
     }
   }
 
   if (types.includes('ip')) {
-    for (const ip of new Set(findPublicIpv4Addresses(text))) {
+    for (const ip of new Set(findPublicIpv4Matches(text).map((match) => match.value))) {
       result = result.split(ip).join(maskText(ip, { visibleStart: 0, visibleEnd: 0, maskChar }));
     }
   }
 
   if (types.includes('jwt')) {
-    for (const jwt of new Set(findJwts(text))) {
+    for (const jwt of new Set(findJwtMatches(text).map((match) => match.value))) {
       result = result.split(jwt).join(maskText(jwt, { visibleStart: 0, visibleEnd: 0, maskChar }));
     }
   }

--- a/src/text/redact.ts
+++ b/src/text/redact.ts
@@ -1,13 +1,40 @@
-import {
-  DetectionType,
-  findApiKeyMatches,
-  findCreditCardMatches,
-  findJwtMatches,
-  findPhoneNumberMatches,
-  findPublicIpv4Matches,
-} from './internal/detectors';
-import { extractEmails } from './extract';
+import { DetectionType, findMatchesByType, TypedMatch } from './internal/detectors';
 import { maskText } from './mask';
+
+// Mask presentation per type -- how much of the match stays visible.
+// Email and phone fall through to maskText's own default (first 2 chars
+// visible); the rest hide everything, except creditCard which keeps the
+// last 4 visible to match the standard "card ending in 1234" convention.
+function maskOptionsFor(
+  type: DetectionType,
+  maskChar: string | undefined,
+): { visibleStart?: number; visibleEnd?: number; maskChar?: string } {
+  if (type === 'creditCard') return { visibleStart: 0, visibleEnd: 4, maskChar };
+  if (type === 'apiKey' || type === 'ip' || type === 'jwt') {
+    return { visibleStart: 0, visibleEnd: 0, maskChar };
+  }
+  return { maskChar };
+}
+
+// Drops any match that overlaps one already kept, in the order matches are
+// given -- so passing them in detector-priority order (as findMatchesByType
+// does) means the higher-priority type wins a same-span overlap (e.g. a
+// digit run that's shaped like both a phone number and a credit card),
+// while purely position-based overlaps elsewhere just resolve to whichever
+// comes first in the text.
+function dropOverlapping(matches: TypedMatch[]): TypedMatch[] {
+  const sorted = [...matches].sort((a, b) => a.start - b.start);
+  const kept: TypedMatch[] = [];
+  let lastEnd = -1;
+
+  for (const match of sorted) {
+    if (match.start < lastEnd) continue;
+    kept.push(match);
+    lastEnd = match.end;
+  }
+
+  return kept;
+}
 
 export interface RedactOptions {
   /** Which types to redact. Default is 'email', 'phone', and 'creditCard'. 'apiKey', 'ip', and 'jwt' are opt-in only, given their higher false-positive risk (or, for 'jwt', simply being a bearer secret rather than classic PII). */
@@ -19,9 +46,9 @@ export interface RedactOptions {
 /**
  * Scans free-form text for embedded PII (emails, phone numbers, credit
  * card numbers, public IPv4 addresses) and secrets (API keys/tokens, JWTs)
- * and masks each match in place, using {@link extractEmails} to locate
- * emails and {@link maskText} to mask every match — for sanitizing logs,
- * support tickets, or user-generated content before storage or display.
+ * and masks each match in place with {@link maskText} — for sanitizing
+ * logs, support tickets, or user-generated content before storage or
+ * display.
  *
  * `redact` is best-effort pattern matching, not a complete PII/secret
  * detector — false negatives are possible, and it shouldn't be relied on
@@ -59,47 +86,16 @@ export function redact(text: string, options: RedactOptions = {}): string {
 
   const { types = ['email', 'phone', 'creditCard'], maskChar } = options;
 
-  let result = text;
+  const matches = dropOverlapping(findMatchesByType(text, types));
 
-  if (types.includes('email')) {
-    for (const email of new Set(extractEmails(text))) {
-      result = result.split(email).join(maskText(email, { maskChar }));
-    }
+  let result = '';
+  let cursor = 0;
+
+  for (const match of matches) {
+    result += text.slice(cursor, match.start);
+    result += maskText(match.value, maskOptionsFor(match.type, maskChar));
+    cursor = match.end;
   }
 
-  if (types.includes('phone')) {
-    for (const phone of new Set(findPhoneNumberMatches(text).map((match) => match.value))) {
-      result = result.split(phone).join(maskText(phone, { maskChar }));
-    }
-  }
-
-  if (types.includes('creditCard')) {
-    for (const card of new Set(findCreditCardMatches(text).map((match) => match.value))) {
-      // Last 4 digits visible matches the standard "card ending in 1234"
-      // convention, rather than full masking.
-      result = result
-        .split(card)
-        .join(maskText(card, { visibleStart: 0, visibleEnd: 4, maskChar }));
-    }
-  }
-
-  if (types.includes('apiKey')) {
-    for (const key of new Set(findApiKeyMatches(text).map((match) => match.value))) {
-      result = result.split(key).join(maskText(key, { visibleStart: 0, visibleEnd: 0, maskChar }));
-    }
-  }
-
-  if (types.includes('ip')) {
-    for (const ip of new Set(findPublicIpv4Matches(text).map((match) => match.value))) {
-      result = result.split(ip).join(maskText(ip, { visibleStart: 0, visibleEnd: 0, maskChar }));
-    }
-  }
-
-  if (types.includes('jwt')) {
-    for (const jwt of new Set(findJwtMatches(text).map((match) => match.value))) {
-      result = result.split(jwt).join(maskText(jwt, { visibleStart: 0, visibleEnd: 0, maskChar }));
-    }
-  }
-
-  return result;
+  return result + text.slice(cursor);
 }

--- a/src/text/scan.ts
+++ b/src/text/scan.ts
@@ -1,0 +1,83 @@
+import {
+  DetectionType,
+  findApiKeyMatches,
+  findCreditCardMatches,
+  findEmailMatches,
+  findJwtMatches,
+  findPhoneNumberMatches,
+  findPublicIpv4Matches,
+} from './internal/detectors';
+
+export interface ScanMatch {
+  /** Which kind of match this is. */
+  type: DetectionType;
+  /** The matched substring, exactly as it appears in the input text. */
+  value: string;
+  /** Index of the match's first character in the input text. */
+  start: number;
+  /** Index one past the match's last character in the input text. */
+  end: number;
+}
+
+export interface ScanOptions {
+  /** Which types to look for. Default is 'email', 'phone', and 'creditCard'. 'apiKey', 'ip', and 'jwt' are opt-in only, given their higher false-positive risk (or, for 'jwt', simply being a bearer secret rather than classic PII). */
+  types?: DetectionType[];
+}
+
+/**
+ * Scans free-form text for the same embedded PII (emails, phone numbers,
+ * credit card numbers, public IPv4 addresses) and secrets (API keys/tokens,
+ * JWTs) that `redact` detects, but returns each match as structured
+ * data instead of masking it in place — for callers that want to inspect,
+ * log, or make their own decision about what was found, rather than have
+ * it masked automatically.
+ *
+ * Reuses exactly the same detection logic `redact` does, so it
+ * carries the same known gaps and false-positive/negative characteristics
+ * — see `redact`'s own documentation for the specifics on `'ip'` and
+ * `'jwt'`. `scan` is best-effort pattern matching, not a complete
+ * PII/secret detector.
+ *
+ * @param text Text to scan.
+ * @param options.types Which types to look for. Default is `'email'`, `'phone'`, and `'creditCard'`. `'apiKey'`, `'ip'`, and `'jwt'` are opt-in only.
+ * @returns Every match found, in the order it appears in the text.
+ * @example
+ * scan('Contact jordan@example.com, card 4111 1111 1111 1111');
+ * // [
+ * //   { type: 'email', value: 'jordan@example.com', start: 8, end: 26 },
+ * //   { type: 'creditCard', value: '4111 1111 1111 1111', start: 33, end: 52 },
+ * // ]
+ */
+export function scan(text: string, options: ScanOptions = {}): ScanMatch[] {
+  if (!text) return [];
+
+  const { types = ['email', 'phone', 'creditCard'] } = options;
+
+  const matches: ScanMatch[] = [];
+
+  if (types.includes('email')) {
+    for (const match of findEmailMatches(text)) matches.push({ type: 'email', ...match });
+  }
+
+  if (types.includes('phone')) {
+    for (const match of findPhoneNumberMatches(text)) matches.push({ type: 'phone', ...match });
+  }
+
+  if (types.includes('creditCard')) {
+    for (const match of findCreditCardMatches(text)) matches.push({ type: 'creditCard', ...match });
+  }
+
+  if (types.includes('apiKey')) {
+    for (const match of findApiKeyMatches(text)) matches.push({ type: 'apiKey', ...match });
+  }
+
+  if (types.includes('ip')) {
+    for (const match of findPublicIpv4Matches(text)) matches.push({ type: 'ip', ...match });
+  }
+
+  if (types.includes('jwt')) {
+    for (const match of findJwtMatches(text)) matches.push({ type: 'jwt', ...match });
+  }
+
+  return matches.sort((a, b) => a.start - b.start);
+}

--- a/src/text/scan.ts
+++ b/src/text/scan.ts
@@ -1,12 +1,4 @@
-import {
-  DetectionType,
-  findApiKeyMatches,
-  findCreditCardMatches,
-  findEmailMatches,
-  findJwtMatches,
-  findPhoneNumberMatches,
-  findPublicIpv4Matches,
-} from './internal/detectors';
+import { DetectionType, findMatchesByType } from './internal/detectors';
 
 export interface ScanMatch {
   /** Which kind of match this is. */
@@ -53,31 +45,5 @@ export function scan(text: string, options: ScanOptions = {}): ScanMatch[] {
 
   const { types = ['email', 'phone', 'creditCard'] } = options;
 
-  const matches: ScanMatch[] = [];
-
-  if (types.includes('email')) {
-    for (const match of findEmailMatches(text)) matches.push({ type: 'email', ...match });
-  }
-
-  if (types.includes('phone')) {
-    for (const match of findPhoneNumberMatches(text)) matches.push({ type: 'phone', ...match });
-  }
-
-  if (types.includes('creditCard')) {
-    for (const match of findCreditCardMatches(text)) matches.push({ type: 'creditCard', ...match });
-  }
-
-  if (types.includes('apiKey')) {
-    for (const match of findApiKeyMatches(text)) matches.push({ type: 'apiKey', ...match });
-  }
-
-  if (types.includes('ip')) {
-    for (const match of findPublicIpv4Matches(text)) matches.push({ type: 'ip', ...match });
-  }
-
-  if (types.includes('jwt')) {
-    for (const match of findJwtMatches(text)) matches.push({ type: 'jwt', ...match });
-  }
-
-  return matches.sort((a, b) => a.start - b.start);
+  return findMatchesByType(text, types).sort((a, b) => a.start - b.start);
 }

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -22,6 +22,7 @@ import { randomString } from './text/randomString';
 import { redact, RedactOptions } from './text/redact';
 import { reverse } from './text/reverse';
 import { sanitize, SanitizeOptions } from './text/sanitize';
+import { scan, ScanMatch, ScanOptions } from './text/scan';
 import { spread } from './text/spread';
 import { isEmail } from './text/validation/email';
 import { isPhoneNumber } from './text/validation/phoneNumber';
@@ -68,6 +69,9 @@ export {
   reverse,
   sanitize,
   SanitizeOptions,
+  scan,
+  ScanMatch,
+  ScanOptions,
   slugify,
   snakeCase,
   spread,

--- a/tests/Text/extract.test.ts
+++ b/tests/Text/extract.test.ts
@@ -28,6 +28,10 @@ describe('#extractEmails', () => {
     expect(extractEmails('Bad ones: @example.com, plainaddress, user@')).toEqual([]);
   });
 
+  it('should reject a domain with no dot even though it is character-class valid', () => {
+    expect(extractEmails('Contact user@localhost for help.')).toEqual([]);
+  });
+
   it('should return an empty array when there are no emails', () => {
     expect(extractEmails('No emails here.')).toEqual([]);
   });

--- a/tests/Text/redact.test.ts
+++ b/tests/Text/redact.test.ts
@@ -84,6 +84,16 @@ describe('#redact', () => {
     expect(redact('Card: 4111 1111 1111 1111')).toBe('Card: ***************1111');
   });
 
+  it('should mask a digit run that is shaped like both a phone number and a credit card only once, preferring phone', () => {
+    // A real (test-only) Amex number: 15 digits, Luhn-valid, and also
+    // within isPhoneNumber's 10-15 digit range for a bare number.
+    const text = 'Amex 378282246310005 on file';
+
+    expect(redact(text, { types: ['phone', 'creditCard'] })).toBe('Amex 37************* on file');
+    // Priority follows detector order, not the order types are listed in.
+    expect(redact(text, { types: ['creditCard', 'phone'] })).toBe('Amex 37************* on file');
+  });
+
   it('should mask known API key/token formats when apiKey is requested', () => {
     // Built by concatenation, not as string literals: GitHub's push
     // protection flags any string matching these providers' key *format*

--- a/tests/Text/scan.test.ts
+++ b/tests/Text/scan.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { scan } from '../../src/textConvert';
+
+describe('#scan', () => {
+  it('should return each default-type match with its position', () => {
+    expect(scan('Contact jordan@example.com, card 4111 1111 1111 1111')).toEqual([
+      { type: 'email', value: 'jordan@example.com', start: 8, end: 26 },
+      { type: 'creditCard', value: '4111 1111 1111 1111', start: 33, end: 52 },
+    ]);
+  });
+
+  it('should return a separate entry for each repeated occurrence of the same value', () => {
+    expect(scan('jordan@example.com appears twice: jordan@example.com')).toEqual([
+      { type: 'email', value: 'jordan@example.com', start: 0, end: 18 },
+      { type: 'email', value: 'jordan@example.com', start: 34, end: 52 },
+    ]);
+  });
+
+  it('should sort matches by position regardless of which type found them', () => {
+    const matches = scan(
+      'Card 4111 1111 1111 1111 then email jordan@example.com then 555-123-4567',
+      { types: ['email', 'phone', 'creditCard'] },
+    );
+
+    expect(matches.map((match) => match.type)).toEqual(['creditCard', 'email', 'phone']);
+    expect(matches).toEqual([
+      { type: 'creditCard', value: '4111 1111 1111 1111', start: 5, end: 24 },
+      { type: 'email', value: 'jordan@example.com', start: 36, end: 54 },
+      { type: 'phone', value: '555-123-4567', start: 60, end: 72 },
+    ]);
+  });
+
+  it('should return an empty array for empty input', () => {
+    expect(scan('')).toEqual([]);
+  });
+
+  it('should return an empty array when there is nothing to find', () => {
+    expect(scan('No PII here.')).toEqual([]);
+  });
+
+  it('should not include apiKey, ip, or jwt in the default types', () => {
+    const fakeAwsKey = 'AKIA' + 'IOSFODNN7EXAMPLE';
+    expect(scan(`Key: ${fakeAwsKey} and card 4111 1111 1111 1111`)).toEqual([
+      { type: 'creditCard', value: '4111 1111 1111 1111', start: 35, end: 54 },
+    ]);
+  });
+
+  it('should find an API key match with its position when apiKey is requested', () => {
+    const fakeAwsKey = 'AKIA' + 'IOSFODNN7EXAMPLE';
+    expect(scan(`Key: ${fakeAwsKey} leaked`, { types: ['apiKey'] })).toEqual([
+      { type: 'apiKey', value: fakeAwsKey, start: 5, end: 25 },
+    ]);
+  });
+
+  it('should only match a public IPv4 address when ip is requested', () => {
+    expect(scan('Server 10.0.0.5 hit by 203.0.113.42', { types: ['ip'] })).toEqual([
+      { type: 'ip', value: '203.0.113.42', start: 23, end: 35 },
+    ]);
+  });
+
+  it('should find a structurally-valid JWT match with its position when jwt is requested', () => {
+    // Built from real base64url-encoded segments, not a hardcoded token
+    // literal -- mirrors the same precaution redact.test.ts takes.
+    const encodeSegment = (payload: unknown) =>
+      Buffer.from(JSON.stringify(payload), 'utf8')
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+    const header = encodeSegment({ alg: 'HS256', typ: 'JWT' });
+    const payload = encodeSegment({ sub: '1234567890' });
+    const signature = 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    const jwt = `${header}.${payload}.${signature}`;
+
+    expect(scan(`Bearer ${jwt}`, { types: ['jwt'] })).toEqual([
+      { type: 'jwt', value: jwt, start: 7, end: 7 + jwt.length },
+    ]);
+  });
+
+  it('should return no matches for an empty types array', () => {
+    expect(scan('jordan@example.com', { types: [] })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

_Provide an overview..._

Adds `scan()`, which exposes `redact()`'s PII/secret detection (emails, phone numbers, credit card numbers, public IPv4 addresses, API keys/tokens, JWTs) as structured `{ type, value, start, end }` matches instead of masking them in place — for callers that want to inspect, log, or make their own decision about what was found.

Also fixes a bug found while reviewing the shared detection logic: `redact()` masked matches with a whole-text `split(value).join(...)` keyed on the matched value, which could silently mask part of unrelated text that merely contained the same substring as a real match (e.g. a matched phone number embedded in a longer, unrelated digit string like an order number). `redact()` now splices each match's mask in at its own position instead, and shares one `findMatchesByType` dispatcher with `scan()` so the two can't drift out of sync. Overlapping matches of different types (e.g. a digit run shaped like both a phone number and a credit card) are now resolved deterministically by detector priority.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

- `scan(text, { types })` — same detection types as `redact`, default `['email', 'phone', 'creditCard']`, `'apiKey'`/`'ip'`/`'jwt'` opt-in only. Returns matches sorted by position.
- Extracted `internal/detectors.ts`: position-aware detection logic (`findEmailMatches`, `findPhoneNumberMatches`, `findCreditCardMatches`, `findApiKeyMatches`, `findPublicIpv4Matches`, `findJwtMatches`) shared by `redact()`, `extractEmails()`, and `scan()`.
- Fixed `redact()` to mask by position instead of by substring value (see summary above), with a new test covering the phone/credit-card overlap case.
- Updated `docs/api/security.md` for both `scan()` and the corrected `redact()` behavior.

### References

Closes #366.