### PR TITLE
feat: add formatNumber function for thousands-separator formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Number to words: Converts numbers < 100 million to English words
 - Ordinal suffixes: turns `21` into `'21st'`
 - Ordinal words: turns `21` into `'twenty-first'`
+- Number formatting: adds thousands separators, e.g. `1234567.89` -> `'1,234,567.89'`
 - Generation: cryptographically secure random strings for IDs, tokens, or test fixtures
 - Grammar: pluralize English words for UI copy like "1 item" / "5 items"
 - Normalization: strip diacritics, collapse whitespace, and normalize line endings
@@ -152,6 +153,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `numbersToWords(number)`                     | Convert a number under 100 million to English words                |
 | `ordinal(number)`                            | Get a number's ordinal suffix form (`21` -> `'21st'`)              |
 | `ordinalToWords(number)`                     | Get a number's ordinal word form (`21` -> `'twenty-first'`)        |
+| `formatNumber(number, options?)`             | Add thousands separators to a number                               |
 | `randomString(length, options?)`             | Generate a cryptographically secure random string                  |
 | `pluralize(word, count?)`                    | Return the plural form of an English word                          |
 | `removeDiacritics(text)`                     | Strip accents from accented characters                             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Security**](api/security.md) — [redact](#redact), [scan](#scan), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml), [sanitize](#sanitize)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate), [wordFrequency](#wordfrequency)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
-- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal), [ordinalToWords](#ordinaltowords)
+- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal), [ordinalToWords](#ordinaltowords), [formatNumber](#formatnumber)
 - [**Generation**](api/generation.md) — [randomString](#randomstring)
 - [**Grammar**](api/grammar.md) — [pluralize](#pluralize)
 - [**Normalization**](api/normalization.md) — [removeDiacritics](#removediacritics), [normalizeWhitespace](#normalizewhitespace), [normalizeLineEndings](#normalizelineendings)
@@ -176,6 +176,10 @@ Full docs: [docs/api/numbers.md#ordinal](api/numbers.md#ordinal)
 ### ordinalToWords
 
 Full docs: [docs/api/numbers.md#ordinaltowords](api/numbers.md#ordinaltowords)
+
+### formatNumber
+
+Full docs: [docs/api/numbers.md#formatnumber](api/numbers.md#formatnumber)
 
 ---
 

--- a/docs/api/numbers.md
+++ b/docs/api/numbers.md
@@ -1,6 +1,6 @@
 # Numbers
 
-`numbersToWords`, `ordinal`, `ordinalToWords`.
+`numbersToWords`, `ordinal`, `ordinalToWords`, `formatNumber`.
 
 ---
 
@@ -95,4 +95,41 @@ ordinalToWords(100); // 'one hundredth'
 - Only the **last word** of `numbersToWords`'s cardinal output changes to its ordinal form — the rest of a compound number stays exactly as `numbersToWords` produced it (`145` -> `'one hundred and forty-fifth'`, not `'one hundred and forty-threeth'` or similar).
 - Irregular endings: `one` -> `first`, `two` -> `second`, `three` -> `third`, `five` -> `fifth`, `eight` -> `eighth`, `nine` -> `ninth`, `twelve` -> `twelfth`. Tens ending in `-y` (`twenty`, `thirty`, ...) become `-ieth` (`twentieth`, `thirtieth`). Everything else just appends `-th` (`four` -> `fourth`, `thousand` -> `thousandth`).
 - Returns `'Please provide a valid number under 100 million'` — rather than throwing — for numbers `>= 100,000,000`, negative numbers, and non-integers, matching `numbersToWords`'s own convention.
+- English only — there's no locale/language parameter.
+
+---
+
+## formatNumber
+
+Formats a number with thousands separators, English/US style (comma thousands separator, period decimal point).
+
+Deliberately **not locale-aware** — no `fr`/`es`/`de`/etc. variants. Native `Intl.NumberFormat` already solves formatted/localized numbers well, and building/maintaining locale data ourselves is a large ongoing maintenance burden this project shouldn't take on — the same reasoning that keeps `numbersToWords` and `detectLanguage` from growing into a full i18n framework.
+
+**Parameters:**
+
+- `number: number` — The number to format.
+- `options.decimals?: number` — Number of decimal places to round/pad to. Omit to preserve the input's natural precision.
+
+**Returns:**
+
+- `string` — The formatted number, or an error message for invalid input.
+
+**Example:**
+
+```js
+import { formatNumber } from 'textconvert';
+
+formatNumber(1234567); // '1,234,567'
+formatNumber(1234567.89); // '1,234,567.89'
+formatNumber(1234.5, { decimals: 2 }); // '1,234.50'
+formatNumber(-1234.5); // '-1,234.5'
+```
+
+**Edge Cases:**
+
+- Omitting `decimals` preserves the input's natural precision — no trailing zeros are added, and nothing is rounded. Specifying `decimals` always pads/rounds to exactly that many places, even if the input had fewer or more (`1234.5` with `{ decimals: 2 }` -> `'1,234.50'`; `1234.567` with `{ decimals: 2 }` -> `'1,234.57'`, rounded).
+- Negative numbers get a leading minus sign (`-1,234.5`) — no accounting-style parentheses option.
+- Numbers at or beyond `1e21` (or `-1e21`) are expanded to their full digit string rather than JavaScript's own scientific notation (`1e+21`) — a double that large is always a whole number (IEEE 754 can't represent a fractional component at that magnitude), so there's no precision lost by expanding it.
+- Very small magnitudes whose natural JS string form uses scientific notation (below roughly `1e-6`, e.g. `0.0000001` -> `'1e-7'`) are **not** expanded — out of scope for v1, unlike the large-number case above.
+- Returns `'Please provide a valid input text'` — rather than throwing — for `NaN`, `Infinity`/`-Infinity`, and a negative or non-integer `decimals` option.
 - English only — there's no locale/language parameter.

--- a/src/numbers/formatNumber.ts
+++ b/src/numbers/formatNumber.ts
@@ -1,0 +1,62 @@
+export interface FormatNumberOptions {
+  /** Number of decimal places to round/pad to. Omit to preserve the input's natural precision. */
+  decimals?: number;
+}
+
+const INVALID_NUMBER_MESSAGE = 'Please provide a valid input text';
+
+// Doubles at or beyond this magnitude are always whole numbers -- IEEE 754
+// can't represent a fractional component that large -- and both
+// Number.prototype.toString and toFixed fall back to scientific notation
+// above it, so this is also the threshold past which digit expansion needs
+// a manual BigInt-based path instead of those.
+const EXPANSION_THRESHOLD = 1e21;
+
+function withThousandsSeparators(digits: string): string {
+  return digits.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+/**
+ * Formats a number with thousands separators, English/US style (comma
+ * thousands separator, period decimal point) -- not locale-aware, see
+ * numbersToWords's own docs for why.
+ * @param number Number to format.
+ * @param options.decimals Number of decimal places to round/pad to. Omit to preserve the input's natural precision.
+ * @returns The formatted number, or the shared invalid-input message for anything that isn't a finite number.
+ * @example
+ * formatNumber(1234567); // '1,234,567'
+ * formatNumber(1234567.89); // '1,234,567.89'
+ * formatNumber(1234.5, { decimals: 2 }); // '1,234.50'
+ * formatNumber(-1234.5); // '-1,234.5'
+ */
+export function formatNumber(number: number, options: FormatNumberOptions = {}): string {
+  const { decimals } = options;
+
+  if (
+    typeof number !== 'number' ||
+    !Number.isFinite(number) ||
+    (decimals !== undefined && (!Number.isInteger(decimals) || decimals < 0))
+  ) {
+    return INVALID_NUMBER_MESSAGE;
+  }
+
+  const isNegative = number < 0;
+  const absNumber = Math.abs(number);
+
+  // Beyond EXPANSION_THRESHOLD, the value is necessarily a whole number (see
+  // above), so there's no real fractional part to round -- any requested
+  // decimals are just zero-padding.
+  const absString =
+    absNumber >= EXPANSION_THRESHOLD
+      ? BigInt(absNumber).toString() + (decimals ? `.${'0'.repeat(decimals)}` : '')
+      : decimals !== undefined
+        ? absNumber.toFixed(decimals)
+        : String(absNumber);
+
+  const [integerPart, fractionPart] = absString.split('.');
+  const formattedInteger = withThousandsSeparators(integerPart);
+  const formatted =
+    fractionPart !== undefined ? `${formattedInteger}.${fractionPart}` : formattedInteger;
+
+  return isNegative ? `-${formatted}` : formatted;
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -27,6 +27,7 @@ import { spread } from './text/spread';
 import { isEmail } from './text/validation/email';
 import { isPhoneNumber } from './text/validation/phoneNumber';
 import { isUrl } from './text/validation/url';
+import { formatNumber, FormatNumberOptions } from './numbers/formatNumber';
 import { numbersToWords } from './numbers/numbersToWords';
 import { ordinal } from './numbers/ordinal';
 import { ordinalToWords } from './numbers/ordinalToWords';
@@ -46,6 +47,8 @@ export {
   extractHashtags,
   extractMentions,
   extractUrls,
+  formatNumber,
+  FormatNumberOptions,
   getTextStats,
   isEmail,
   isPalindrome,

--- a/tests/Numbers/formatNumber.test.ts
+++ b/tests/Numbers/formatNumber.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { formatNumber } from '../../src/textConvert';
+
+describe('#formatNumber', () => {
+  it('should add thousands separators to an integer', () => {
+    expect(formatNumber(1234567)).toBe('1,234,567');
+  });
+
+  it('should preserve natural precision when decimals is omitted', () => {
+    expect(formatNumber(1234567.89)).toBe('1,234,567.89');
+    expect(formatNumber(1234.5)).toBe('1,234.5');
+  });
+
+  it('should round and pad to the requested number of decimals', () => {
+    expect(formatNumber(1234.5, { decimals: 2 })).toBe('1,234.50');
+    expect(formatNumber(1234.567, { decimals: 2 })).toBe('1,234.57');
+    expect(formatNumber(1234.5, { decimals: 0 })).toBe('1,235');
+  });
+
+  it('should not add a decimal point for a whole number under 1000', () => {
+    expect(formatNumber(42)).toBe('42');
+  });
+
+  it('should format a negative number with a leading minus sign', () => {
+    expect(formatNumber(-1234.5)).toBe('-1,234.5');
+    expect(formatNumber(-1234.567, { decimals: 2 })).toBe('-1,234.57');
+  });
+
+  it('should not show a minus sign for negative zero', () => {
+    expect(formatNumber(-0)).toBe('0');
+  });
+
+  it('should format zero', () => {
+    expect(formatNumber(0)).toBe('0');
+    expect(formatNumber(0, { decimals: 2 })).toBe('0.00');
+  });
+
+  it('should expand a number at or beyond 1e21 to its full digit string rather than scientific notation', () => {
+    expect(formatNumber(1e21)).toBe('1,000,000,000,000,000,000,000');
+    expect(formatNumber(-1e21)).toBe('-1,000,000,000,000,000,000,000');
+  });
+
+  it('should zero-pad decimals for a number at or beyond 1e21, since it has no real fractional part', () => {
+    expect(formatNumber(1e21, { decimals: 2 })).toBe('1,000,000,000,000,000,000,000.00');
+  });
+
+  it('should still add thousands separators just below the expansion threshold', () => {
+    // A literal this large loses precision at parse time (rounding up to
+    // exactly 1e21) -- built via Number() to sidestep eslint's
+    // no-loss-of-precision rule while still exercising that same rounding.
+    expect(formatNumber(Number('999999999999999999999'))).toBe('1,000,000,000,000,000,000,000');
+    expect(formatNumber(123456789012345680000)).toBe('123,456,789,012,345,680,000');
+  });
+
+  it("should return 'Please provide a valid input text' for NaN", () => {
+    expect(formatNumber(NaN)).toBe('Please provide a valid input text');
+  });
+
+  it("should return 'Please provide a valid input text' for Infinity and -Infinity", () => {
+    expect(formatNumber(Infinity)).toBe('Please provide a valid input text');
+    expect(formatNumber(-Infinity)).toBe('Please provide a valid input text');
+  });
+
+  it("should return 'Please provide a valid input text' for a negative or non-integer decimals option", () => {
+    expect(formatNumber(1234.5, { decimals: -1 })).toBe('Please provide a valid input text');
+    expect(formatNumber(1234.5, { decimals: 1.5 })).toBe('Please provide a valid input text');
+  });
+});


### PR DESCRIPTION
## Summary

`#387`

Adds `formatNumber(number, options?)`, which formats a number with thousands separators, English/US style (comma thousands separator, period decimal point) -- deliberately not locale-aware, since `Intl.NumberFormat` already covers that well and maintaining locale data ourselves is a burden this project shouldn't take on (same reasoning as `numbersToWords`/`detectLanguage`).

The issue was labeled `needs-decision`; the open questions were settled with the maintainer before implementation:
- `decimals` rounds (not truncates) when the input has more decimal places than requested; omitting it preserves the input's natural precision.
- Negative numbers use a leading minus sign, no accounting-style parens option in v1.
- Numbers at or beyond `1e21` are expanded to their full digit string instead of scientific notation, since a double that large is always a whole number (no fractional precision to lose).
- `NaN`, `Infinity`/`-Infinity`, and an invalid `decimals` option fall back to the library's shared invalid-input sentinel string, matching every other string-returning function's convention.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

- `src/numbers/formatNumber.ts` — implementation, exported from `textConvert.ts`.
- `tests/Numbers/formatNumber.test.ts` — covers natural-precision vs fixed-decimals formatting, rounding, negative numbers, negative zero, the `1e21` expansion boundary (and just below it), and invalid input (`NaN`, `Infinity`, bad `decimals`).
- `docs/api/numbers.md`, `docs/API.md`, `README.md` — documented in a separate commit, following this repo's usual code/docs split.

### References

Closes #387.