### PR TITLE
feat: add parseNumber function to parse formatted numbers back to values

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ _Provide an overview..._
 
 - [ ] Created failing tests before adding any code.
 - [ ] All existing and new tests passed after adding code.
-- [ ] Extended [README.md](/README.md) file if necessary.
+- [ ] Extended [README.md](README.md) file if necessary.
 - [ ] Followed style rules.
 - [ ] Linted code before pushing.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ _Provide an overview..._
 
 - [ ] Created failing tests before adding any code.
 - [ ] All existing and new tests passed after adding code.
-- [ ] Extended [README.md](README.md) file if necessary.
+- [ ] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
 - [ ] Followed style rules.
 - [ ] Linted code before pushing.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 - Ordinal suffixes: turns `21` into `'21st'`
 - Ordinal words: turns `21` into `'twenty-first'`
 - Number formatting: adds thousands separators, e.g. `1234567.89` -> `'1,234,567.89'`
+- Number parsing: turns `'1,234,567.89'` back into `1234567.89`
 - Generation: cryptographically secure random strings for IDs, tokens, or test fixtures
 - Grammar: pluralize English words for UI copy like "1 item" / "5 items"
 - Normalization: strip diacritics, collapse whitespace, and normalize line endings
@@ -154,6 +155,7 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 | `ordinal(number)`                            | Get a number's ordinal suffix form (`21` -> `'21st'`)              |
 | `ordinalToWords(number)`                     | Get a number's ordinal word form (`21` -> `'twenty-first'`)        |
 | `formatNumber(number, options?)`             | Add thousands separators to a number                               |
+| `parseNumber(text)`                          | Parse a formatted number string back into a number                 |
 | `randomString(length, options?)`             | Generate a cryptographically secure random string                  |
 | `pluralize(word, count?)`                    | Return the plural form of an English word                          |
 | `removeDiacritics(text)`                     | Strip accents from accented characters                             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ Detailed documentation for every function has moved into per-category files unde
 - [**Security**](api/security.md) — [redact](#redact), [scan](#scan), [maskText](#masktext), [escapeHtml](#escapehtml), [unescapeHtml](#unescapehtml), [sanitize](#sanitize)
 - [**Text Analysis**](api/text-analysis.md) — [clear](#clear), [count](#count), [countWords](#countwords), [countSentences](#countsentences), [getTextStats](#gettextstats), [isPalindrome](#ispalindrome), [reverse](#reverse), [spread](#spread), [truncate](#truncate), [wordFrequency](#wordfrequency)
 - [**Language**](api/language.md) — [detectLanguage](#detectlanguage)
-- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal), [ordinalToWords](#ordinaltowords), [formatNumber](#formatnumber)
+- [**Numbers**](api/numbers.md) — [numbersToWords](#numberstowords), [ordinal](#ordinal), [ordinalToWords](#ordinaltowords), [formatNumber](#formatnumber), [parseNumber](#parsenumber)
 - [**Generation**](api/generation.md) — [randomString](#randomstring)
 - [**Grammar**](api/grammar.md) — [pluralize](#pluralize)
 - [**Normalization**](api/normalization.md) — [removeDiacritics](#removediacritics), [normalizeWhitespace](#normalizewhitespace), [normalizeLineEndings](#normalizelineendings)
@@ -180,6 +180,10 @@ Full docs: [docs/api/numbers.md#ordinaltowords](api/numbers.md#ordinaltowords)
 ### formatNumber
 
 Full docs: [docs/api/numbers.md#formatnumber](api/numbers.md#formatnumber)
+
+### parseNumber
+
+Full docs: [docs/api/numbers.md#parsenumber](api/numbers.md#parsenumber)
 
 ---
 

--- a/docs/api/numbers.md
+++ b/docs/api/numbers.md
@@ -1,6 +1,6 @@
 # Numbers
 
-`numbersToWords`, `ordinal`, `ordinalToWords`, `formatNumber`.
+`numbersToWords`, `ordinal`, `ordinalToWords`, `formatNumber`, `parseNumber`.
 
 ---
 
@@ -133,3 +133,36 @@ formatNumber(-1234.5); // '-1,234.5'
 - Very small magnitudes whose natural JS string form uses scientific notation (below roughly `1e-6`, e.g. `0.0000001` -> `'1e-7'`) are **not** expanded — out of scope for v1, unlike the large-number case above.
 - Returns `'Please provide a valid input text'` — rather than throwing — for `NaN`, `Infinity`/`-Infinity`, and a negative or non-integer `decimals` option.
 - English only — there's no locale/language parameter.
+
+---
+
+## parseNumber
+
+Parses a formatted number string back into a numeric value — the reverse of `formatNumber`.
+
+**Parameters:**
+
+- `text: string` — The text to parse.
+
+**Returns:**
+
+- `number` — The parsed number, or `NaN` for anything that isn't `formatNumber`-shaped. `NaN`, not the shared string sentinel, since this returns a `number`.
+
+**Example:**
+
+```js
+import { parseNumber } from 'textconvert';
+
+parseNumber('1,234,567'); // 1234567
+parseNumber('1,234.56'); // 1234.56
+parseNumber('-1,234.5'); // -1234.5
+```
+
+**Edge Cases:**
+
+- Guarantees `parseNumber(formatNumber(n)) === n` for every `n` `formatNumber` can produce (including its `1e21`-and-beyond digit-expansion case).
+- Accepts input `formatNumber` itself wouldn't produce, but that's still unambiguous: surrounding whitespace is trimmed, and a plain number with no thousands separators at all is accepted even for values `formatNumber` would always group (e.g. `'1234567'` parses the same as `'1,234,567'`).
+- Rejects incorrectly-grouped thousands separators (`'1,23,456'`, `'12,3456'`) rather than silently stripping commas and parsing whatever digits are left — a malformed grouping fails to parse at all.
+- Rejects a leading currency symbol (`'$1,234.56'`) — out of scope, the same reasoning that keeps `formatNumber` from being locale-aware.
+- Returns `NaN` for anything that isn't a string, is empty/whitespace-only, or doesn't match one of the accepted shapes above (e.g. `'1.'`, `'1,234.56.78'`, `'not a number'`).
+- English/US number format only — there's no locale/language parameter.

--- a/src/numbers/parseNumber.ts
+++ b/src/numbers/parseNumber.ts
@@ -1,0 +1,30 @@
+// Matches exactly what formatNumber produces (an optional leading '-', an
+// integer part that's either ungrouped digits or correctly comma-grouped
+// in threes, and an optional '.'-prefixed decimal part), plus a couple of
+// deliberate extra leniencies: missing thousands separators are accepted
+// (the ungrouped-digits branch) even though formatNumber always groups
+// numbers >= 1000, since a plain typed-in number is a natural thing to
+// feed this. Incorrectly-grouped separators (e.g. '1,23,456') are
+// rejected -- the grouped branch requires every group after the first to
+// be exactly 3 digits, so a malformed one fails to match at all rather
+// than silently parsing partial digits.
+const PARSE_NUMBER_PATTERN = /^-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?$/;
+
+/**
+ * Parses a formatted number string back into a numeric value -- the
+ * reverse of formatNumber.
+ * @param text Text to parse.
+ * @returns The parsed number, or NaN for anything that isn't formatNumber-shaped.
+ * @example
+ * parseNumber('1,234,567'); // 1234567
+ * parseNumber('1,234.56'); // 1234.56
+ * parseNumber('-1,234.5'); // -1234.5
+ */
+export function parseNumber(text: string): number {
+  if (typeof text !== 'string') return NaN;
+
+  const trimmed = text.trim();
+  if (!PARSE_NUMBER_PATTERN.test(trimmed)) return NaN;
+
+  return Number(trimmed.replace(/,/g, ''));
+}

--- a/src/textConvert.ts
+++ b/src/textConvert.ts
@@ -31,6 +31,7 @@ import { formatNumber, FormatNumberOptions } from './numbers/formatNumber';
 import { numbersToWords } from './numbers/numbersToWords';
 import { ordinal } from './numbers/ordinal';
 import { ordinalToWords } from './numbers/ordinalToWords';
+import { parseNumber } from './numbers/parseNumber';
 import { slugify } from './text/slugify';
 import { truncate } from './text/truncate';
 
@@ -63,6 +64,7 @@ export {
   numbersToWords,
   ordinal,
   ordinalToWords,
+  parseNumber,
   pascalCase,
   pluralize,
   randomString,

--- a/tests/Numbers/parseNumber.test.ts
+++ b/tests/Numbers/parseNumber.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { formatNumber, parseNumber } from '../../src/textConvert';
+
+describe('#parseNumber', () => {
+  it('should parse a comma-grouped integer', () => {
+    expect(parseNumber('1,234,567')).toBe(1234567);
+  });
+
+  it('should parse a comma-grouped decimal', () => {
+    expect(parseNumber('1,234.56')).toBe(1234.56);
+  });
+
+  it('should parse a negative number with a leading minus sign', () => {
+    expect(parseNumber('-1,234.5')).toBe(-1234.5);
+  });
+
+  it('should parse a number with no thousands separators', () => {
+    expect(parseNumber('1234567')).toBe(1234567);
+    expect(parseNumber('42')).toBe(42);
+  });
+
+  it('should trim surrounding whitespace', () => {
+    expect(parseNumber(' 1,234.56 ')).toBe(1234.56);
+    expect(parseNumber('\t-42\n')).toBe(-42);
+  });
+
+  it('should parse zero', () => {
+    expect(parseNumber('0')).toBe(0);
+    expect(parseNumber('0.00')).toBe(0);
+  });
+
+  it('should round-trip every formatNumber output back to the original value', () => {
+    const values = [0, 42, 999, 1000, 1234567, 1234567.89, -1234.5, 1e21, -1e21];
+
+    for (const value of values) {
+      expect(parseNumber(formatNumber(value))).toBe(value);
+      expect(parseNumber(formatNumber(value, { decimals: 2 }))).toBe(value);
+    }
+  });
+
+  it('should reject incorrectly-grouped thousands separators', () => {
+    expect(Number.isNaN(parseNumber('1,23,456'))).toBe(true);
+    expect(Number.isNaN(parseNumber('12,3456'))).toBe(true);
+  });
+
+  it('should reject a leading currency symbol', () => {
+    expect(Number.isNaN(parseNumber('$1,234.56'))).toBe(true);
+  });
+
+  it('should reject malformed input', () => {
+    expect(Number.isNaN(parseNumber(''))).toBe(true);
+    expect(Number.isNaN(parseNumber('   '))).toBe(true);
+    expect(Number.isNaN(parseNumber('-'))).toBe(true);
+    expect(Number.isNaN(parseNumber('1.'))).toBe(true);
+    expect(Number.isNaN(parseNumber('1,234.56.78'))).toBe(true);
+    expect(Number.isNaN(parseNumber('not a number'))).toBe(true);
+  });
+
+  it('should return NaN for non-string input', () => {
+    expect(Number.isNaN(parseNumber(null as unknown as string))).toBe(true);
+    expect(Number.isNaN(parseNumber(undefined as unknown as string))).toBe(true);
+    expect(Number.isNaN(parseNumber(1234 as unknown as string))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`#388`

Adds `parseNumber(text)`, the reverse of `formatNumber` -- parses a formatted number string (comma thousands separator, period decimal point, optional leading minus sign) back into a numeric value.

The issue was labeled `needs-decision` and blocked by `#387` (formatNumber); now that #387 is merged, the accepted input format is anchored to what it actually produces. The open leniency questions were settled with the maintainer before implementation:
- Surrounding whitespace is trimmed.
- A plain number with no thousands separators is accepted, even for values `formatNumber` would always group (e.g. `'1234567'` parses the same as `'1,234,567'`).
- A leading currency symbol (`'$1,234.56'`) is rejected -- out of scope, same reasoning that keeps `formatNumber` from being locale-aware.
- Incorrectly-grouped thousands separators (`'1,23,456'`, `'12,3456'`) are rejected rather than silently stripping commas and parsing whatever's left.
- Invalid/unparseable input returns `NaN`, matching JS's own `Number()` convention -- this returns a `number`, not a `string`, so the library's usual sentinel-string convention doesn't fit.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

- `src/numbers/parseNumber.ts` -- implementation, exported from `textConvert.ts`.
- `tests/Numbers/parseNumber.test.ts` -- covers basic parsing, whitespace trimming, missing separators, a round-trip test against every `formatNumber` output (including its `1e21` expansion case), rejected malformed grouping/currency symbols, and invalid input.
- `docs/api/numbers.md`, `docs/API.md`, `README.md` -- documented in a separate commit, following this repo's usual code/docs split.

### References

Closes #388.