### PR TITLE
docs: add a MIGRATION.md upgrade guide, tracked alongside v3.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ For this project, that includes:
 - Changing the shared "invalid input" convention most functions follow (returning `'Please provide a valid input text'` instead of throwing) — since it's used across most of the library, changing it is breaking everywhere at once, not just for one function.
 - Raising the minimum Node version in `engines.node`, or changing the build output (e.g. dropping CJS support).
 
+**Also update when shipping a breaking change:** add or update its entry in [MIGRATION.md](MIGRATION.md), with concrete before/after guidance — the `BREAKING CHANGE:` footer feeds CHANGELOG.md automatically, but a terse one-paragraph footer isn't the same as an upgrade guide, especially when several breaking changes land in the same major version.
+
 ## Deprecation Policy
 
 Before removing or renaming a public function, deprecate it first — give consumers a documented warning period rather than dropping something with zero notice in the next major release. Nothing in the library is deprecated yet; this section exists so there's a clear, agreed-on process ready for whenever that first happens.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,15 @@
+# Migration Guide
+
+Upgrade notes for each major version, with concrete before/after guidance for every breaking change. See [CHANGELOG.md](CHANGELOG.md) for the full release history, including non-breaking changes.
+
+---
+
+## Upgrading to v3.0.0 (unreleased)
+
+Tracked in [#328](https://github.com/Monsieur-Nico/textConvert/issues/328). Each item below is filled in with real before/after details in the PR that implements it, and checked off alongside its matching checkbox in #328 — check back here, not just the CHANGELOG, before upgrading past v2.x.
+
+- [ ] **ISO 639-1 language codes** ([#329](https://github.com/Monsieur-Nico/textConvert/issues/329)) — `detectLanguage`'s `Language` enum will use codes (`'en'`, `'fr'`, ...) instead of English names (`'English'`, `'French'`, ...).
+- [ ] **ESM-only, CJS dropped** ([#331](https://github.com/Monsieur-Nico/textConvert/issues/331)) — `require('textconvert')` will no longer work; use `import` instead.
+- [ ] **`spread()`'s return type and error messages** ([#389](https://github.com/Monsieur-Nico/textConvert/issues/389)) — fixes its inconsistent return type and stale error messages.
+- [ ] **Parameter style unification** ([#390](https://github.com/Monsieur-Nico/textConvert/issues/390)) — `count`, `spread`, and/or `pluralize` may move from positional flags to an options object. Still under consideration — may be closed without action, in which case this line will be removed rather than checked off.
+- [ ] **`numbersToWords`'s missing "and"** ([#393](https://github.com/Monsieur-Nico/textConvert/issues/393)) — adds the same `'and'` the hundred-branch already inserts (e.g. `'one hundred and five'`) to the thousand/million branches too, for numbers whose remainder is under 100 (e.g. `'one hundred thousand and five'`, not `'one hundred thousand five'`).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ redact('Contact me at jordan@example.com or 555-123-4567');
 - [Advanced Examples](#advanced-examples)
 - [Contributing](#contributing)
 - [Changelog](#changelog)
+- [Migration Guide](#migration-guide)
 - [License](#license)
 - [Contributors ✨](#contributors-)
 
@@ -228,6 +229,12 @@ If you are adding a new function, follow the step-by-step instructions in [docs/
 ## Changelog
 
 See [CHANGELOG.md](./CHANGELOG.md) for release history and updates.
+
+---
+
+## Migration Guide
+
+Upgrading across a major version? See [MIGRATION.md](./MIGRATION.md) for concrete before/after guidance on every breaking change.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dist",
     "README.md",
     "LICENSE",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "MIGRATION.md"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Adds `MIGRATION.md` at the repo root, a per-major-version upgrade guide with concrete before/after guidance for breaking changes -- distinct from `CHANGELOG.md`'s auto-compiled `BREAKING CHANGE:` footers, which are fine for one isolated breaking change but don't add up to a coherent upgrade guide when several land in the same major version, as `#328`'s six candidates will.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [x] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

- `MIGRATION.md` -- seeded with a "v3.0.0 (unreleased)" section listing the 5 actual breaking candidates from `#328` (`#329`, `#331`, `#389`, `#390`, `#393`) as unchecked items, excluding `#386`'s new `wordsToNumber` since adding a function isn't itself breaking. Each item gets filled in with real before/after details in the PR that implements it.
- `README.md` -- new "Migration Guide" TOC entry and section.
- `package.json` -- added `MIGRATION.md` to `files`, so it ships with the npm package alongside `CHANGELOG.md`.
- `CONTRIBUTING.md` -- new standing instruction under the breaking-change criteria: update `MIGRATION.md` whenever shipping any breaking change going forward, not just for this release.
- `#328` -- updated to link `MIGRATION.md` and ask contributors to check off both lists together.

### References

Part of #328.