### PR TITLE
ci: auto-post all-contributors trigger comment on push to main

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,20 @@
+name: contributors
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JoshuaKGoldberg/all-contributors-auto-action@v0.6.1
+        with:
+          ignored-logins: |
+            -\[bot\]$


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

Adds a workflow that automatically keeps the README contributors section up to date, instead of requiring a maintainer to manually run `all-contributors add`.

### PR checklist

- [ ] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [ ] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [ ] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [x] Other (please describe):
  > CI workflow addition (no application code changed).

### Details

Adds `.github/workflows/contributors.yml`, which runs `JoshuaKGoldberg/all-contributors-auto-action` on every push to `main`. It detects recent contributors and posts the `@all-contributors please add ...` trigger comment automatically, instead of a maintainer typing it by hand. Bot accounts (e.g. `dependabot[bot]`) are excluded via `ignored-logins`.

This repo already follows the [all-contributors](https://allcontributors.org/) spec (`.all-contributorsrc` + the README markers), so no changes to that convention are needed — this only automates the trigger step.

**Requires:** the [all-contributors GitHub App](https://allcontributors.org/docs/en/bot/usage) must be installed on this repo for the posted comment to actually open an update PR to `.all-contributorsrc` / README.

### References

- [all-contributors-auto-action](https://github.com/JoshuaKGoldberg/all-contributors-auto-action)
- [all-contributors bot usage docs](https://allcontributors.org/docs/en/bot/usage)
