### PR TITLE
fix: pass GITHUB_TOKEN to all-contributors-auto-action

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: JoshuaKGoldberg/all-contributors-auto-action@v0.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           ignored-logins: |
             -\[bot\]$


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

Fixes the `contributors` workflow added in #436, which failed on its first run on `main` with `Error: Parameter token or opts.auth is required`.

### PR checklist

- [ ] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [ ] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [ ] Linted code before pushing.

## PR type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

`JoshuaKGoldberg/all-contributors-auto-action` doesn't expose a token as an action `input` — it reads `process.env.GITHUB_TOKEN` (or `GH_TOKEN`) directly. The original workflow didn't set that env var on the step, so the action crashed immediately trying to authenticate. This adds:

```yaml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

to the step, matching how the action actually reads its credentials.

### References

- Failing run from #436's merge: workflow crash log with `Error: Parameter token or opts.auth is required`
- [all-contributors-auto-action](https://github.com/JoshuaKGoldberg/all-contributors-auto-action)
