### PR TITLE
ci: continue-on-error on all-contributors-auto-action pending upstream fix

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -14,7 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Fails on repos with 300+ recent events: the underlying
+      # all-contributors-for-repository lib over-paginates GitHub's events
+      # endpoint. Fix is up but still a draft:
+      # https://github.com/JoshuaKGoldberg/all-contributors-for-repository/pull/1292
       - uses: JoshuaKGoldberg/all-contributors-auto-action@v0.6.1
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

Stops the `contributors` workflow from failing on every push to `main` due to an upstream bug we can't fix from this repo.

### PR checklist

- [ ] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [ ] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [ ] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [x] Other (please describe):
  > CI workflow tweak (no application code changed).

### Details

Even with a valid `GITHUB_TOKEN` (#437), `JoshuaKGoldberg/all-contributors-auto-action` fails on this repo with:

```
RequestError [HttpError]: In order to keep the API fast for everyone, pagination is limited for this resource.
```

Root cause: the underlying library, `all-contributors-for-repository`, always tries to page through up to 500 events, but GitHub's `/repos/{owner}/{repo}/events` endpoint hard-caps pagination at 300 items (3 pages of 100) — it 422s on page 4. This repo has enough recent activity to hit that cap. There's an open (draft) upstream fix at [JoshuaKGoldberg/all-contributors-for-repository#1292](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/pull/1292), but it hasn't merged or shipped in a release yet, and neither the library nor the action exposes an option to cap the event count ourselves.

This adds `continue-on-error: true` to the step, with a comment linking to the fix PR, so the workflow stops failing loudly while we wait on the upstream fix. A scheduled check-in is set for 2026-09-14 to remove this once the fix ships.

### References

- [all-contributors-for-repository#1292](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/pull/1292)
- #436, #437 (prior work on this workflow)
