### PR TITLE
fix: correct maintainer contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at nicolas@alkhoury.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at nicolas@nicoscript.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
   },
   "sideEffects": false,
   "contributors": [
-    "Nicolas Alkhoury <nicolas@alkhoury.com> (https://github.com/Monsieur-Nico)"
+    "Nicolas Alkhoury <nicolas@nicoscript.com> (https://github.com/Monsieur-Nico)"
   ],
   "lint-staged": {
     "*.{ts,js,json,md}": [


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

Fixes the maintainer contact email, which was wrong in two places: `nicolas@alkhoury.com` is incorrect, the correct address is `nicolas@nicoscript.com`.

### PR checklist

- [ ] Created failing tests before adding any code.
- [ ] All existing and new tests passed after adding code.
- [ ] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
  > _Explain here._

### Details

`CODE_OF_CONDUCT.md`'s enforcement contact used `nicolas@alkhoury.com`, copied from `package.json`'s `contributors` field on the assumption that it was correct since it was already public. It wasn't -- fixed both, since `package.json`'s copy is the same wrong address, pre-existing before this PR and already published in prior npm releases.

### References

- Follow-up to #405 / #448 (Code of Conduct addition)
