### PR TITLE
ci: wire up independent release-please tracking for the 3.x line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, '*.x']
   pull_request:
-    branches: [main]
+    branches: [main, '*.x']
 
 jobs:
   test:

--- a/.github/workflows/release-please-3.x.yml
+++ b/.github/workflows/release-please-3.x.yml
@@ -1,8 +1,12 @@
-name: release-please
+name: release-please-3.x
 
+# Maintenance line for the v3.x major: publishes patch/minor releases off
+# this branch, completely independent of whatever's accumulating on `main`
+# for the next major. See CONTRIBUTING.md's "Maintaining a Prior Major
+# Version" section.
 on:
   push:
-    branches: [main]
+    branches: [3.x]
 
 permissions:
   contents: write
@@ -21,6 +25,7 @@ jobs:
           release-type: node
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: 3.x
 
   publish:
     needs: release-please
@@ -42,8 +47,13 @@ jobs:
         run: npm install -g npm@latest
       - name: Build
         run: npm run build
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - name: Publish to npm under the v3 dist-tag
+        # Never publish this line under the implicit `latest` tag -- npm
+        # always points `latest` at whatever was most recently published,
+        # regardless of version number, so an untagged publish here would
+        # incorrectly make a v3.x patch what `npm install textconvert`
+        # resolves to even after v4 exists.
+        run: npm publish --tag v3 --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Sync jsr.json version with package.json


### PR DESCRIPTION
# Conventional Commit Message Format

Please use the Conventional Commits format for your commits:

`<type>: <short summary>`

**Allowed types:**

- feat: ✨ Features
- fix: 🐛 Fixes
- refactor: 🧼 Refactors
- docs: 📚 Documentation
- test: ✅ Tests
- chore: 🔧 Chores

**Example:**
`feat: add support for Dutch language detection`

---

## Summary

Wires up independent release tracking for the new `3.x` maintenance branch, per #442's plan -- so an urgent v3.x hotfix can ship without waiting on whatever's accumulating on `main` for v4.

### PR checklist

- [ ] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [ ] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [x] Other (please describe):
  > CI/release workflow setup for this branch specifically (no application code changed).

### Details

- Renamed `release-please.yml` to `release-please-3.x.yml` on this branch (main keeps its own independent copy at the original filename) -- avoids any confusion between the two in the Actions run history, since they're now permanently divergent by design.
- Retargeted it to trigger on push to `3.x`, with `target-branch: 3.x` passed to the release-please action, so it tracks/publishes this branch's own version line completely independently of `main`.
- Changed its `npm publish` step to `--tag v3` instead of the implicit `latest` -- npm always points `latest` at whatever was most recently published regardless of version number, so an untagged publish here would incorrectly make a v3.x patch what `npm install textconvert` resolves to once v4 ships from `main`.
- No new manifest file needed -- `.release-please-manifest.json` is already correctly seeded at `3.0.0`, inherited from the `v3.0.0` tag this branch was cut from.
- Extended `ci.yml`'s branch triggers from a hardcoded `[main]` to `[main, '*.x']`, so PRs into this branch (and any future `N.x` maintenance branch) actually get tested/linted -- previously they'd have silently gotten zero CI coverage.

### References

- #442 (maintenance-branch strategy tracking issue)
