### PR TITLE
fix: grapheme-cluster awareness for spread() and count()

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,50 +127,50 @@ Reads from the given file, or from stdin if no file is given; always writes to s
 
 ## 📋 API Reference
 
-| Function                                     | Description                                                        |
-| -------------------------------------------- | ------------------------------------------------------------------ |
-| `camelCase(text)`                            | Convert to camelCase                                               |
-| `pascalCase(text)`                           | Convert to PascalCase                                              |
-| `snakeCase(text)`                            | Convert to snake_case                                              |
-| `kebabCase(text)`                            | Convert to kebab-case                                              |
-| `slugify(text)`                              | Convert to a URL-safe slug                                         |
-| `capitalize(text)`                           | Capitalize only the first letter                                   |
-| `titleCase(text)`                            | Capitalize the first letter of every word                          |
-| `clear(text)`                                | Remove punctuation from text                                       |
-| `count(text, countNumbers?)`                 | Count letters (optionally including numbers)                       |
-| `countWords(text)`                           | Count words                                                        |
-| `countSentences(text)`                       | Count sentences                                                    |
-| `reverse(text)`                              | Reverse a string (grapheme-cluster aware)                          |
-| `spread(text, clear?)`                       | Split a string into an array of characters                         |
-| `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis (grapheme-safe cut) |
-| `maskText(text, options?)`                   | Partially mask a string for display                                |
-| `redact(text, options?)`                     | Mask PII/secrets embedded in text                                  |
-| `scan(text, options?)`                       | Find PII/secrets embedded in text as structured matches            |
-| `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time, readability) |
-| `isPalindrome(text)`                         | Check if text is a palindrome                                      |
-| `wordFrequency(text)`                        | Count how many times each word appears                             |
-| `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                             |
-| `numbersToWords(number)`                     | Convert a number under 100 million to English words                |
-| `wordsToNumber(text)`                        | Parse English number-words back into a number                      |
-| `ordinal(number)`                            | Get a number's ordinal suffix form (`21` -> `'21st'`)              |
-| `ordinalToWords(number)`                     | Get a number's ordinal word form (`21` -> `'twenty-first'`)        |
-| `formatNumber(number, options?)`             | Add thousands separators to a number                               |
-| `parseNumber(text)`                          | Parse a formatted number string back into a number                 |
-| `randomString(length, options?)`             | Generate a cryptographically secure random string                  |
-| `pluralize(word, count?)`                    | Return the plural form of an English word                          |
-| `removeDiacritics(text)`                     | Strip accents from accented characters                             |
-| `normalizeWhitespace(text)`                  | Collapse whitespace runs into a single space                       |
-| `normalizeLineEndings(text)`                 | Normalize CRLF/CR line endings to LF                               |
-| `isEmail(text)`                              | Validate an email address                                          |
-| `isUrl(text)`                                | Validate a URL                                                     |
-| `isPhoneNumber(text)`                        | Validate a phone number                                            |
-| `extractEmails(text)`                        | Extract all email addresses found in a block of text               |
-| `extractUrls(text)`                          | Extract all URLs found in a block of text                          |
-| `extractMentions(text)`                      | Extract all @mentions found in a block of text                     |
-| `extractHashtags(text)`                      | Extract all #hashtags found in a block of text                     |
-| `escapeHtml(text)`                           | Escape the five HTML special characters                            |
-| `unescapeHtml(text)`                         | Reverse `escapeHtml`'s escaping                                    |
-| `sanitize(text, options?)`                   | Trim, normalize, redact, and escape in one configurable pipeline   |
+| Function                                     | Description                                                         |
+| -------------------------------------------- | ------------------------------------------------------------------- |
+| `camelCase(text)`                            | Convert to camelCase                                                |
+| `pascalCase(text)`                           | Convert to PascalCase                                               |
+| `snakeCase(text)`                            | Convert to snake_case                                               |
+| `kebabCase(text)`                            | Convert to kebab-case                                               |
+| `slugify(text)`                              | Convert to a URL-safe slug                                          |
+| `capitalize(text)`                           | Capitalize only the first letter                                    |
+| `titleCase(text)`                            | Capitalize the first letter of every word                           |
+| `clear(text)`                                | Remove punctuation from text                                        |
+| `count(text, countNumbers?)`                 | Count letters (optionally including numbers), grapheme-aware        |
+| `countWords(text)`                           | Count words                                                         |
+| `countSentences(text)`                       | Count sentences                                                     |
+| `reverse(text)`                              | Reverse a string (grapheme-cluster aware)                           |
+| `spread(text, clear?)`                       | Split a string into an array of characters (grapheme-cluster aware) |
+| `truncate(text, maxLength, options?)`        | Shorten text to a max length, with an ellipsis (grapheme-safe cut)  |
+| `maskText(text, options?)`                   | Partially mask a string for display                                 |
+| `redact(text, options?)`                     | Mask PII/secrets embedded in text                                   |
+| `scan(text, options?)`                       | Find PII/secrets embedded in text as structured matches             |
+| `getTextStats(text, wordsPerMinute?)`        | Full text statistics (counts, averages, reading time, readability)  |
+| `isPalindrome(text)`                         | Check if text is a palindrome                                       |
+| `wordFrequency(text)`                        | Count how many times each word appears                              |
+| `detectLanguage(text, minLength?, options?)` | Detect the language of a piece of text                              |
+| `numbersToWords(number)`                     | Convert a number under 100 million to English words                 |
+| `wordsToNumber(text)`                        | Parse English number-words back into a number                       |
+| `ordinal(number)`                            | Get a number's ordinal suffix form (`21` -> `'21st'`)               |
+| `ordinalToWords(number)`                     | Get a number's ordinal word form (`21` -> `'twenty-first'`)         |
+| `formatNumber(number, options?)`             | Add thousands separators to a number                                |
+| `parseNumber(text)`                          | Parse a formatted number string back into a number                  |
+| `randomString(length, options?)`             | Generate a cryptographically secure random string                   |
+| `pluralize(word, count?)`                    | Return the plural form of an English word                           |
+| `removeDiacritics(text)`                     | Strip accents from accented characters                              |
+| `normalizeWhitespace(text)`                  | Collapse whitespace runs into a single space                        |
+| `normalizeLineEndings(text)`                 | Normalize CRLF/CR line endings to LF                                |
+| `isEmail(text)`                              | Validate an email address                                           |
+| `isUrl(text)`                                | Validate a URL                                                      |
+| `isPhoneNumber(text)`                        | Validate a phone number                                             |
+| `extractEmails(text)`                        | Extract all email addresses found in a block of text                |
+| `extractUrls(text)`                          | Extract all URLs found in a block of text                           |
+| `extractMentions(text)`                      | Extract all @mentions found in a block of text                      |
+| `extractHashtags(text)`                      | Extract all #hashtags found in a block of text                      |
+| `escapeHtml(text)`                           | Escape the five HTML special characters                             |
+| `unescapeHtml(text)`                         | Reverse `escapeHtml`'s escaping                                     |
+| `sanitize(text, options?)`                   | Trim, normalize, redact, and escape in one configurable pipeline    |
 
 See [docs/API.md](docs/API.md) for full parameter, return type, and edge-case details on every function, or browse the auto-generated [API reference site](https://monsieur-nico.github.io/textConvert/).
 

--- a/docs/api/text-analysis.md
+++ b/docs/api/text-analysis.md
@@ -73,6 +73,7 @@ count('Hello0 world', true); // 11
 
 - Returns 0 for empty input.
 - Runs the string through `clear` first (see above), so punctuation and spaces are already excluded before counting begins — you're counting letters (and optionally digits) only, never symbols or whitespace.
+- Letters are counted per grapheme cluster (user-perceived character), so a letter written as base + combining marks (unnormalized input like `cafe\u0301`) counts once, not once per code point. Multi-code-point emoji count as 0 (they're not letters). The letter/digit classification itself is unchanged and ASCII-only, exactly as before — this only regroups the iteration unit.
 
 ---
 
@@ -274,13 +275,14 @@ import { spread } from 'textconvert';
 
 spread('Hello, world!'); // ['H', 'e', 'l', 'l', 'o', ',', ' ', 'w', 'o', 'r', 'l', 'd', '!']
 spread('hello world'); // ['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd']
+spread('👍🏽'); // ['👍🏽'] -- one element, not three code points
 ```
 
 **Edge Cases:**
 
 - Returns `[]` for invalid input type, or empty/whitespace-only string.
 - Every character of the input is preserved verbatim, including case and whitespace — `spread(text).join('')` round-trips the original text (when `clear` is `false`). `clear: true` only removes punctuation; it also lowercases the text and can leave a trailing space, since that's `clear`'s own documented behavior, not something `spread` adds on top.
-- Character splitting uses the spread operator (`[...text]`), which is surrogate-pair-aware — unlike `reverse` (see above), `spread` handles astral Unicode characters (most emoji) as single array entries correctly.
+- Character splitting uses grapheme clusters (via `Intl.Segmenter`, the same segmentation `reverse` and `truncate` use), so multi-code-point characters stay intact as single array entries: astral-plane emoji, ZWJ sequences (like 👨‍👩‍👧‍👦), flags, skin-tone modifiers, keycaps, and unnormalized combining marks (like `e` + U+0301) each come out as one element rather than being split into separate code points.
 
 ---
 

--- a/src/text/count.ts
+++ b/src/text/count.ts
@@ -1,7 +1,12 @@
 import { clear } from './clear';
+import { iterateGraphemes } from './internal/graphemes';
 
 /**
- * Return a boolean value number of the letters in a string.
+ * Return a number count of the letters in a string.
+ *
+ * Letters are counted per grapheme cluster (user-perceived character), so a
+ * letter with combining marks (e.g. an unnormalized `é`) counts once, not once
+ * per code point.
  *
  * @param text String input to get letters count from.
  * @param countNumbers boolean value to determine if numbers should be counted as letters.
@@ -10,6 +15,7 @@ import { clear } from './clear';
  * @example
  * count('Hello, world!'); // 10
  * count('Hello0 world', true); // 11
+ * count('cafe\u0301'); // 4 -- the e+combining-acute cluster counts once
  */
 
 export function count(text: string, countNumbers = false): number {
@@ -17,23 +23,18 @@ export function count(text: string, countNumbers = false): number {
   if (!text.length) return 0;
   // Create a temp number.
   let temp = 0;
-  // Clear the string and split the letters into an array.
-  const cleared = clear(text).split('');
-  // Loop through the letters array.
-  cleared.forEach((letter) => {
-    // Check if countNumbers is included
-    if (!countNumbers) {
-      // Count letters only
-      if (!(/[a-z]/g.test(letter) || /[A-Z]/g.test(letter))) {
-        return;
-      }
+  // Clear the string, then walk it grapheme cluster by grapheme cluster so
+  // multi-code-point characters (combining marks, emoji) count once.
+  const cleared = clear(text);
+  for (const cluster of iterateGraphemes(cleared)) {
+    // A cluster's base character is its first code point -- classify by it so
+    // combining marks and modifiers attached to the base don't change how the
+    // cluster is counted. The ASCII-only classes match the historical
+    // behavior of this function; this change only regroups the iteration.
+    if (countNumbers ? /^[a-z0-9]/i.test(cluster) : /^[a-z]/i.test(cluster)) {
       temp++;
-      return;
     }
-    // Count letters with numbers.
-    if (!(/[a-z]/g.test(letter) || /[A-Z]/g.test(letter) || /[0-9]/g.test(letter))) return;
-    temp++;
-  });
+  }
 
   // Return the number of letters.
   return temp;

--- a/src/text/spread.ts
+++ b/src/text/spread.ts
@@ -8,7 +8,22 @@
  * spread('Hello, world!', true); // ['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', ' '] -- clearText also lowercases and can leave a trailing space
  */
 import { clear as clearText } from './clear';
+import { graphemes } from './internal/graphemes';
 
+/**
+ * Splits a string into an array of its characters, in order.
+ *
+ * Characters are grapheme clusters (user-perceived characters), so multi-code-point
+ * sequences -- ZWJ emoji, flags, skin-tone modifiers, combining marks -- stay intact
+ * as single elements instead of being split into separate code points.
+ * @param text A string to spread.
+ * @param clear Whether to clear punctuation from the text first. Default is false.
+ * @returns Array of characters, or `[]` for invalid input -- not the shared string sentinel, since this returns `string[]`.
+ * @example
+ * spread('Hello, world!'); // ['H', 'e', 'l', 'l', 'o', ',', ' ', 'w', 'o', 'r', 'l', 'd', '!']
+ * spread('👍🏽'); // ['👍🏽'] -- one element, not three code points
+ * spread('Hello, world!', true); // ['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', ' '] -- clearText also lowercases and can leave a trailing space
+ */
 export function spread(text: string, clear = false): string[] {
   if (typeof text !== 'string' || !text.trim()) {
     return [];
@@ -19,5 +34,7 @@ export function spread(text: string, clear = false): string[] {
     text = clearText(text);
   }
 
-  return [...text];
+  // Grapheme clusters rather than code points, matching the segmentation
+  // used by reverse() and truncate().
+  return graphemes(text);
 }

--- a/tests/Text/count.test.ts
+++ b/tests/Text/count.test.ts
@@ -28,6 +28,25 @@ describe('#count', () => {
   it('should return 5 for a string with only numbers and counting numbers', () => {
     expect(count('12345', true)).toBe(5);
   });
+
+  it('should count a letter with combining marks once (NFD input)', () => {
+    // 'cafe\u0301' is NFD: 'e' + combining acute. The e counts once, not per code point.
+    expect(count('cafe\u0301')).toBe(4);
+    // countNumbers variant: digits followed by a marked letter
+    expect(count('ab1e\u0301', true)).toBe(4);
+  });
+
+  it('should not split or miscount multi-code-point emoji', () => {
+    // One grapheme cluster with a non-letter base: counts as 0, not per code point
+    expect(count('👍🏽')).toBe(0);
+    expect(count('👍🏽', true)).toBe(0);
+  });
+
+  it('should count ZWJ-joined letters as one letter each', () => {
+    // The historic behavior split 'a\u200Db' into a, ZWJ(no), b => 2;
+    // cluster-based iteration yields the same total through a different path.
+    expect(count('a\u200Db')).toBe(2);
+  });
 });
 
 describe('#countWords', () => {

--- a/tests/Text/spread.test.ts
+++ b/tests/Text/spread.test.ts
@@ -43,6 +43,21 @@ describe('#spread', () => {
     ]);
   });
 
+  it('should keep multi-code-point emoji as single elements', () => {
+    expect(spread('👍🏽')).toEqual(['👍🏽']);
+    expect(spread('👨‍👩‍👧‍👦')).toEqual(['👨‍👩‍👧‍👦']);
+  });
+
+  it('should keep flags and keycap sequences intact', () => {
+    expect(spread('🇯🇵')).toEqual(['🇯🇵']);
+    expect(spread('1️⃣')).toEqual(['1️⃣']);
+  });
+
+  it('should keep unnormalized combining marks attached to their base letter', () => {
+    // 'cafe\u0301' is NFD: the final cluster is 'e' + U+0301 (combining acute)
+    expect(spread('cafe\u0301')).toEqual(['c', 'a', 'f', 'e\u0301']);
+  });
+
   it('should return [] for invalid input type', () => {
     // @ts-expect-error Testing runtime behavior with incorrect types
     expect(spread(123)).toEqual([]);


### PR DESCRIPTION
# #445

Grapheme-cluster awareness for `spread()` and `count()`, reusing the `Intl.Segmenter` infrastructure #412 introduced for `reverse()`/`truncate()` (`src/text/internal/graphemes.ts`) — the approach the issue proposes.

## What changes

**`spread()`** — `[...text]` (code points) → `graphemes(text)` (clusters). This is the user-visible fix: ZWJ sequences (👨‍👩‍👧‍👦), flags (🇯🇵), skin-tone modifiers (👍🏽), keycaps (1️⃣) and unnormalized combining marks (`cafe\u0301`) now come out as one element instead of being split per code point.

**`count()`** — `clear(text).split('')` (UTF-16 code units) → cluster iteration, classifying each cluster by its base (first code point). Two properties worth calling out:

- The letter/digit classes stay exactly as they were — ASCII-only, no Unicode expansion. This PR regroups the iteration unit; it does not change what counts as a letter.
- Classification by base code point (not whole-cluster match) is what makes NFD input count correctly: matching whole clusters against `[a-z]` would make `cafe\u0301` count 3 instead of 4 — a regression against current behavior, where the combining mark is skipped and the base `e` matches.

For `count()` this is a behavior-preserving regroup for realistic inputs (combining marks were skipped before and contribute 0 now; base letters counted before and still count). It is observable only where the old behavior was already arbitrary — e.g. ZWJ-joined letters `a\u200Db` counted 2 before (a + b, ZWJ skipped) and still counts 2 (clusters `a`, `b`); a keycap `1️⃣` counted 0 and still counts 0 (or 1 with `countNumbers: true` under both, by its base digit).

## Versioning (the issue's explicit question)

Recommending **no major bump** — explicitly left to maintainer decision:

- #330's precedent (which the issue cites): fixing previously-wrong output for multi-codepoint input was treated as a fix, not a breaking change.
- `count()` is behavior-preserving in practice (analysis above).
- `spread()` does change output for multi-code-point input, but that is "fixing previously-wrong output" by the #330 framing; and v3.0.0 (released today) already carried `spread()`'s return-type change, so landing this after it rides in a minor (3.1.0) rather than being mixed into that major's changeset — matching the issue's scoping note about not bundling into the same release without a clear reason.

## Red-green verification

- **RED**: with the source changes stashed, the 3 new spread tests fail against the old implementation (emoji as single elements / flags and keycaps / combining marks attached to base); the other 26 pass. No new count test is red against the old implementation — by design, since realistic-input behavior is preserved; the new count tests pin cluster-level counting under both implementations.
- **GREEN**: after restoring the implementation, full suite below.

| Check | Result |
|---|---|
| `npm test` | ✅ 440/440 passed (30 files) |
| `npm run lint` (eslint) | ✅ clean |
| `npx tsc --noEmit -p tsconfig.json` | ✅ clean |
| Behavior spot-checks | 👍🏽 → 1 element; 🇯🇵 → 1; 1️⃣ → 1; `cafe\u0301` → 4 elements, count 4; `a\u200Db` → 2 elements, count 2 |
| Edge cases covered | combining marks (NFD), ZWJ family emoji, flag, keycap, countNumbers interplay |

## Scope & limitations

- Only `spread()` and `count()` are touched — no other function, no dependencies, nothing bundled. The stale note about `reverse`'s pre-#412 code-unit behavior in `docs/api/text-analysis.md` is out of scope for this PR.
- `clear()`'s documented quirks (lowercasing, possible trailing space) are unchanged; it runs before segmentation, and its ASCII punctuation regex can't split a combining sequence.
- `count()`'s JSDoc example writes `cafe\u0301` explicitly instead of a precomposed `café`, so the example stays correct regardless of source-file normalization form.

### PR checklist

- [x] Created failing tests before adding any code.
- [x] All existing and new tests passed after adding code.
- [x] Extended [README.md](https://github.com/Monsieur-Nico/textConvert/blob/main/README.md) file if necessary.
- [x] Followed style rules.
- [x] Linted code before pushing.

## PR type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, renaming).
- [ ] Refactoring (no functional changes).
- [ ] Documentation content changes.
- [ ] Other (please describe):
